### PR TITLE
✨ Session names, tags, active status, and last-interaction time

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { URL } from 'url';
 import { getOrCreateToken, authMiddleware, validateWsToken } from './auth.js';
 import { sessionManager } from './session-manager.js';
 import { listHistoricalSessions, getSessionDetail, getSessionMessages } from './session-store.js';
+import { getAllMeta, updateMeta, addTag, removeTag } from './session-meta.js';
 import type { WsMessage, WsServerMessage } from './types.js';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
@@ -28,7 +29,14 @@ app.get('/api/health', (_req, res) => {
 });
 
 app.get('/api/sessions', (_req, res) => {
-  res.json(sessionManager.getAllSessions());
+  const sessions = sessionManager.getAllSessions();
+  const meta = getAllMeta();
+  const enriched = sessions.map(s => ({
+    ...s,
+    name: meta[s.id]?.name,
+    tags: meta[s.id]?.tags || [],
+  }));
+  res.json(enriched);
 });
 
 app.post('/api/sessions', async (req, res) => {
@@ -42,10 +50,15 @@ app.post('/api/sessions', async (req, res) => {
 });
 
 app.get('/api/sessions/:id', (req, res) => {
+  const meta = getAllMeta();
+  const sessionMeta = meta[req.params.id] || {};
+
   const managed = sessionManager.getSession(req.params.id);
   if (managed) {
     res.json({
       ...managed.session,
+      name: sessionMeta.name,
+      tags: sessionMeta.tags || [],
       messages: managed.messages.slice(-100),
     });
     return;
@@ -54,10 +67,32 @@ app.get('/api/sessions/:id', (req, res) => {
   const historical = getSessionDetail(req.params.id);
   if (historical) {
     const messages = getSessionMessages(req.params.id);
-    res.json({ ...historical, messages: messages.slice(-200) });
+    res.json({ ...historical, name: sessionMeta.name, tags: sessionMeta.tags || [], messages: messages.slice(-200) });
     return;
   }
   res.status(404).json({ error: 'Session not found' });
+});
+
+// Session metadata CRUD
+app.patch('/api/sessions/:id/meta', (req, res) => {
+  const { name, tags } = req.body;
+  const update: Record<string, any> = {};
+  if (name !== undefined) update.name = name;
+  if (tags !== undefined) update.tags = tags;
+  const result = updateMeta(req.params.id, update);
+  res.json(result);
+});
+
+app.post('/api/sessions/:id/tags', (req, res) => {
+  const { tag } = req.body;
+  if (!tag) { res.status(400).json({ error: 'tag required' }); return; }
+  const tags = addTag(req.params.id, tag);
+  res.json({ tags });
+});
+
+app.delete('/api/sessions/:id/tags/:tag', (req, res) => {
+  const tags = removeTag(req.params.id, req.params.tag);
+  res.json({ tags });
 });
 
 app.delete('/api/sessions/:id', (req, res) => {

--- a/server/src/session-meta.ts
+++ b/server/src/session-meta.ts
@@ -1,0 +1,62 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const META_DIR = join(homedir(), '.copilot-remote');
+const META_FILE = join(META_DIR, 'session-meta.json');
+
+export interface SessionMeta {
+  name?: string;
+  tags?: string[];
+}
+
+type MetaStore = Record<string, SessionMeta>;
+
+function load(): MetaStore {
+  try {
+    if (existsSync(META_FILE)) {
+      return JSON.parse(readFileSync(META_FILE, 'utf-8'));
+    }
+  } catch { /* ignore */ }
+  return {};
+}
+
+function save(store: MetaStore) {
+  if (!existsSync(META_DIR)) mkdirSync(META_DIR, { recursive: true });
+  writeFileSync(META_FILE, JSON.stringify(store, null, 2));
+}
+
+export function getMeta(sessionId: string): SessionMeta {
+  return load()[sessionId] || {};
+}
+
+export function getAllMeta(): MetaStore {
+  return load();
+}
+
+export function updateMeta(sessionId: string, update: Partial<SessionMeta>): SessionMeta {
+  const store = load();
+  const current = store[sessionId] || {};
+  store[sessionId] = { ...current, ...update };
+  save(store);
+  return store[sessionId];
+}
+
+export function addTag(sessionId: string, tag: string): string[] {
+  const store = load();
+  const current = store[sessionId] || {};
+  const tags = new Set(current.tags || []);
+  tags.add(tag);
+  store[sessionId] = { ...current, tags: [...tags] };
+  save(store);
+  return store[sessionId].tags!;
+}
+
+export function removeTag(sessionId: string, tag: string): string[] {
+  const store = load();
+  const current = store[sessionId] || {};
+  const tags = (current.tags || []).filter(t => t !== tag);
+  store[sessionId] = { ...current, tags };
+  save(store);
+  return tags;
+}

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -18,6 +18,8 @@ export function listHistoricalSessions(): Session[] {
   if (!existsSync(SESSION_STATE_DIR)) return [];
 
   const sessions: Session[] = [];
+  const now = Date.now();
+  const ACTIVE_THRESHOLD_MS = 120_000; // 2 minutes
 
   try {
     const entries = readdirSync(SESSION_STATE_DIR, { withFileTypes: true });
@@ -33,13 +35,23 @@ export function listHistoricalSessions(): Session[] {
         const data = parseYaml(raw) as WorkspaceYaml;
         const stat = statSync(workspacePath);
 
+        // Check if events.jsonl was recently modified (session is active in a terminal)
+        const eventsPath = join(SESSION_STATE_DIR, entry.name, 'events.jsonl');
+        let isActive = false;
+        let lastInteraction: string | undefined;
+        try {
+          const eventsStat = statSync(eventsPath);
+          isActive = (now - eventsStat.mtimeMs) < ACTIVE_THRESHOLD_MS;
+          lastInteraction = eventsStat.mtime.toISOString();
+        } catch { /* no events file */ }
+
         sessions.push({
           id: data.id || entry.name,
           cwd: data.cwd || '',
           summary: data.summary,
-          status: 'exited',
+          status: isActive ? 'active' : 'exited',
           createdAt: data.created_at || stat.birthtime.toISOString(),
-          updatedAt: data.updated_at || stat.mtime.toISOString(),
+          updatedAt: lastInteraction || data.updated_at || stat.mtime.toISOString(),
         });
       } catch {
         // Skip malformed session directories

--- a/server/src/session-watcher.ts
+++ b/server/src/session-watcher.ts
@@ -1,13 +1,13 @@
-import { watch, readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { readFileSync, readdirSync, existsSync, statSync, openSync, readSync, closeSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import type { ChatMessage } from './types.js';
 
 const SESSION_STATE_DIR = join(homedir(), '.copilot', 'session-state');
+const POLL_INTERVAL_MS = 1500;
 
-// Track file offsets so we only process new lines
+// Track byte offsets for efficient tailing
 const fileOffsets = new Map<string, number>();
-const watchers = new Map<string, ReturnType<typeof watch>>();
 
 type MessageCallback = (sessionId: string, message: ChatMessage) => void;
 
@@ -19,98 +19,109 @@ function parseEvent(line: string): { type: string; data: any; id?: string; times
   }
 }
 
-function processNewLines(sessionId: string, eventsPath: string, callback: MessageCallback) {
+function readNewBytes(eventsPath: string): string | null {
   try {
     const stat = statSync(eventsPath);
     const currentOffset = fileOffsets.get(eventsPath) || 0;
+    if (stat.size <= currentOffset) return null;
 
-    if (stat.size <= currentOffset) return;
-
-    const fd = readFileSync(eventsPath, 'utf-8');
-    const newContent = fd.slice(currentOffset);
-    fileOffsets.set(eventsPath, fd.length);
-
-    const lines = newContent.split('\n').filter(l => l.trim());
-
-    for (const line of lines) {
-      const event = parseEvent(line);
-      if (!event) continue;
-
-      if (event.type === 'user.message' && event.data?.content) {
-        callback(sessionId, {
-          id: event.id || '',
-          role: 'user',
-          content: event.data.content,
-          timestamp: event.timestamp || '',
-        });
-      } else if (event.type === 'assistant.message' && event.data?.content) {
-        callback(sessionId, {
-          id: event.data.messageId || event.id || '',
-          role: 'copilot',
-          content: event.data.content,
-          timestamp: event.timestamp || '',
-        });
-      }
+    const bytesToRead = stat.size - currentOffset;
+    const buf = Buffer.alloc(bytesToRead);
+    const fd = openSync(eventsPath, 'r');
+    try {
+      readSync(fd, buf, 0, bytesToRead, currentOffset);
+    } finally {
+      closeSync(fd);
     }
+    fileOffsets.set(eventsPath, stat.size);
+    return buf.toString('utf-8');
   } catch {
-    // File read error — skip
+    return null;
   }
 }
 
-function watchSession(sessionId: string, callback: MessageCallback) {
-  const eventsPath = join(SESSION_STATE_DIR, sessionId, 'events.jsonl');
-  if (!existsSync(eventsPath) || watchers.has(sessionId)) return;
+function processNewLines(sessionId: string, eventsPath: string, callback: MessageCallback) {
+  const newContent = readNewBytes(eventsPath);
+  if (!newContent) return;
 
-  // Set initial offset to end of file so we only get new events
-  try {
-    const content = readFileSync(eventsPath, 'utf-8');
-    fileOffsets.set(eventsPath, content.length);
-  } catch {
-    return;
+  const lines = newContent.split('\n').filter(l => l.trim());
+
+  for (const line of lines) {
+    const event = parseEvent(line);
+    if (!event) continue;
+
+    if (event.type === 'user.message' && event.data?.content) {
+      callback(sessionId, {
+        id: event.id || '',
+        role: 'user',
+        content: event.data.content,
+        timestamp: event.timestamp || '',
+      });
+    } else if (event.type === 'assistant.message' && event.data?.content) {
+      callback(sessionId, {
+        id: event.data.messageId || event.id || '',
+        role: 'copilot',
+        content: event.data.content,
+        timestamp: event.timestamp || '',
+      });
+    }
   }
+}
 
+function initOffset(eventsPath: string) {
   try {
-    const watcher = watch(eventsPath, (eventType) => {
-      if (eventType === 'change') {
-        processNewLines(sessionId, eventsPath, callback);
-      }
-    });
-    watchers.set(sessionId, watcher);
+    const stat = statSync(eventsPath);
+    fileOffsets.set(eventsPath, stat.size);
   } catch {
-    // Watch failed
+    // Ignore
   }
 }
 
 export function watchSessionEvents(callback: MessageCallback) {
   if (!existsSync(SESSION_STATE_DIR)) return { stop: () => {} };
 
-  // Watch existing session directories
+  // Initialize offsets for all existing sessions
   try {
     const entries = readdirSync(SESSION_STATE_DIR, { withFileTypes: true });
     for (const entry of entries) {
       if (entry.isDirectory()) {
-        watchSession(entry.name, callback);
+        const eventsPath = join(SESSION_STATE_DIR, entry.name, 'events.jsonl');
+        if (existsSync(eventsPath)) {
+          initOffset(eventsPath);
+        }
       }
     }
   } catch {
-    // Can't read session state dir
+    // Ignore
   }
 
-  // Watch for new session directories
-  const dirWatcher = watch(SESSION_STATE_DIR, (eventType, filename) => {
-    if (filename && !watchers.has(filename)) {
-      const sessionDir = join(SESSION_STATE_DIR, filename);
-      if (existsSync(sessionDir) && statSync(sessionDir).isDirectory()) {
-        watchSession(filename, callback);
+  // Poll all sessions for changes
+  const interval = setInterval(() => {
+    try {
+      const entries = readdirSync(SESSION_STATE_DIR, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const eventsPath = join(SESSION_STATE_DIR, entry.name, 'events.jsonl');
+        if (!existsSync(eventsPath)) continue;
+
+        // Initialize offset for new sessions
+        if (!fileOffsets.has(eventsPath)) {
+          initOffset(eventsPath);
+          continue;
+        }
+
+        processNewLines(entry.name, eventsPath, callback);
       }
+    } catch {
+      // Ignore polling errors
     }
-  });
+  }, POLL_INTERVAL_MS);
+
+  console.log(`👀 Watching ${fileOffsets.size} session(s) for live updates (polling every ${POLL_INTERVAL_MS}ms)`);
 
   return {
     stop: () => {
-      dirWatcher.close();
-      for (const w of watchers.values()) w.close();
-      watchers.clear();
+      clearInterval(interval);
     },
   };
 }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -2,7 +2,7 @@ export interface Session {
   id: string;
   cwd: string;
   summary?: string;
-  status: 'running' | 'idle' | 'exited';
+  status: 'running' | 'active' | 'idle' | 'exited';
   createdAt: string;
   updatedAt: string;
   pid?: number;

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,6 +1,25 @@
-import { Box, Text, ActionList, Button, Spinner, Label, RelativeTime } from '@primer/react';
-import { PlusIcon, SyncIcon } from '@primer/octicons-react';
+import { useState, useCallback } from 'react';
+import { Box, Text, ActionList, Button, Spinner, Label, RelativeTime, TextInput } from '@primer/react';
+import { PlusIcon, SyncIcon, PencilIcon, XIcon, TagIcon } from '@primer/octicons-react';
+import { api } from '../lib/api';
 import type { Session } from '../types';
+
+const TAG_COLORS: Record<string, { bg: string; fg: string }> = {
+  kubestellar: { bg: '#1f6feb33', fg: '#58a6ff' },
+  clubtivi: { bg: '#f7830833', fg: '#f78308' },
+  infra: { bg: '#8b949e33', fg: '#8b949e' },
+  bug: { bg: '#da363333', fg: '#f85149' },
+  feature: { bg: '#23863633', fg: '#3fb950' },
+  docs: { bg: '#a371f733', fg: '#bc8cff' },
+};
+
+function getTagStyle(tag: string) {
+  const lower = tag.toLowerCase();
+  for (const [key, style] of Object.entries(TAG_COLORS)) {
+    if (lower.includes(key)) return style;
+  }
+  return { bg: '#30363d', fg: '#8b949e' };
+}
 
 interface Props {
   sessions: Session[];
@@ -13,9 +32,15 @@ interface Props {
 }
 
 export function SessionList({ sessions, loading, error, activeId, onSelect, onNew, onRefresh }: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [addingTagId, setAddingTagId] = useState<string | null>(null);
+  const [newTag, setNewTag] = useState('');
+
   const statusColor = (s: Session['status']) => {
     switch (s) {
       case 'running': return 'success.fg';
+      case 'active': return 'success.fg';
       case 'idle': return 'attention.fg';
       case 'exited': return 'fg.muted';
     }
@@ -24,10 +49,42 @@ export function SessionList({ sessions, loading, error, activeId, onSelect, onNe
   const statusLabel = (s: Session['status']) => {
     switch (s) {
       case 'running': return 'Running';
+      case 'active': return 'Active';
       case 'idle': return 'Idle';
       case 'exited': return 'Ended';
     }
   };
+
+  const handleStartRename = useCallback((e: React.MouseEvent, session: Session) => {
+    e.stopPropagation();
+    setEditingId(session.id);
+    setEditName(session.name || session.summary || '');
+  }, []);
+
+  const handleSaveRename = useCallback(async (sessionId: string) => {
+    if (editName.trim()) {
+      await api.updateSessionMeta(sessionId, { name: editName.trim() });
+      onRefresh();
+    }
+    setEditingId(null);
+  }, [editName, onRefresh]);
+
+  const handleAddTag = useCallback(async (sessionId: string) => {
+    if (newTag.trim()) {
+      await api.addTag(sessionId, newTag.trim());
+      onRefresh();
+    }
+    setNewTag('');
+    setAddingTagId(null);
+  }, [newTag, onRefresh]);
+
+  const handleRemoveTag = useCallback(async (e: React.MouseEvent, sessionId: string, tag: string) => {
+    e.stopPropagation();
+    await api.removeTag(sessionId, tag);
+    onRefresh();
+  }, [onRefresh]);
+
+  const displayName = (s: Session) => s.name || s.summary || s.cwd.split('/').pop() || s.id.slice(0, 8);
 
   return (
     <Box sx={{ p: 2 }}>
@@ -50,14 +107,76 @@ export function SessionList({ sessions, loading, error, activeId, onSelect, onNe
             <ActionList.LeadingVisual>
               <Box sx={{ width: 8, height: 8, borderRadius: '50%', bg: statusColor(session.status) }} />
             </ActionList.LeadingVisual>
-            <Box sx={{ overflow: 'hidden' }}>
-              <Text sx={{ fontSize: 1, fontWeight: session.id === activeId ? 'bold' : 'normal', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {session.summary || session.cwd.split('/').pop() || session.id.slice(0, 8)}
-              </Text>
-              <Box sx={{ display: 'flex', gap: 1, mt: 1, alignItems: 'center' }}>
-                <Label variant={session.status === 'running' ? 'success' : 'secondary'} sx={{ fontSize: 0 }}>
+            <Box sx={{ overflow: 'hidden', width: '100%' }}>
+              {editingId === session.id ? (
+                <Box sx={{ display: 'flex', gap: 1 }} onClick={e => e.stopPropagation()}>
+                  <TextInput
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleSaveRename(session.id); if (e.key === 'Escape') setEditingId(null); }}
+                    size="small"
+                    sx={{ flex: 1, fontSize: 0 }}
+                    autoFocus
+                  />
+                </Box>
+              ) : (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Text sx={{ fontSize: 1, fontWeight: session.id === activeId ? 'bold' : 'normal', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                    {displayName(session)}
+                  </Text>
+                  <Box
+                    as="button"
+                    sx={{ bg: 'transparent', border: 'none', color: 'fg.muted', cursor: 'pointer', p: 0, display: 'flex', flexShrink: 0, ':hover': { color: 'fg.default' } }}
+                    onClick={(e: React.MouseEvent) => handleStartRename(e, session)}
+                    aria-label="Rename"
+                  >
+                    <PencilIcon size={12} />
+                  </Box>
+                </Box>
+              )}
+              <Box sx={{ display: 'flex', gap: 1, mt: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                <Label variant={session.status === 'running' || session.status === 'active' ? 'success' : 'secondary'} sx={{ fontSize: 0 }}>
                   {statusLabel(session.status)}
                 </Label>
+                {(session.tags || []).map(tag => {
+                  const style = getTagStyle(tag);
+                  return (
+                    <Box
+                      key={tag}
+                      sx={{ display: 'inline-flex', alignItems: 'center', gap: '2px', px: '6px', py: '1px', borderRadius: '12px', fontSize: 0, fontWeight: 600, bg: style.bg, color: style.fg }}
+                    >
+                      {tag}
+                      <Box
+                        as="button"
+                        sx={{ bg: 'transparent', border: 'none', color: 'inherit', cursor: 'pointer', p: 0, display: 'flex', opacity: 0.7, ':hover': { opacity: 1 } }}
+                        onClick={(e: React.MouseEvent) => handleRemoveTag(e, session.id, tag)}
+                      >
+                        <XIcon size={10} />
+                      </Box>
+                    </Box>
+                  );
+                })}
+                {addingTagId === session.id ? (
+                  <Box onClick={e => e.stopPropagation()}>
+                    <input
+                      value={newTag}
+                      onChange={e => setNewTag(e.target.value)}
+                      onKeyDown={e => { if (e.key === 'Enter') handleAddTag(session.id); if (e.key === 'Escape') { setAddingTagId(null); setNewTag(''); } }}
+                      placeholder="tag"
+                      autoFocus
+                      style={{ width: 60, fontSize: 10, padding: '1px 4px', borderRadius: 4, border: '1px solid #30363d', background: '#0d1117', color: '#e6edf3' }}
+                    />
+                  </Box>
+                ) : (
+                  <Box
+                    as="button"
+                    sx={{ bg: 'transparent', border: 'none', color: 'fg.muted', cursor: 'pointer', p: 0, display: 'flex', ':hover': { color: 'fg.default' } }}
+                    onClick={(e: React.MouseEvent) => { e.stopPropagation(); setAddingTagId(session.id); }}
+                    aria-label="Add tag"
+                  >
+                    <TagIcon size={12} />
+                  </Box>
+                )}
                 <Text sx={{ color: 'fg.muted', fontSize: 0 }}>
                   <RelativeTime date={new Date(session.updatedAt)} />
                 </Text>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -39,4 +39,13 @@ export const api = {
 
   killSession: (id: string) =>
     request<{ killed: boolean }>(`/api/sessions/${id}`, { method: 'DELETE' }),
+
+  updateSessionMeta: (id: string, meta: { name?: string; tags?: string[] }) =>
+    request<{ name?: string; tags?: string[] }>(`/api/sessions/${id}/meta`, { method: 'PATCH', body: JSON.stringify(meta) }),
+
+  addTag: (id: string, tag: string) =>
+    request<{ tags: string[] }>(`/api/sessions/${id}/tags`, { method: 'POST', body: JSON.stringify({ tag }) }),
+
+  removeTag: (id: string, tag: string) =>
+    request<{ tags: string[] }>(`/api/sessions/${id}/tags/${encodeURIComponent(tag)}`, { method: 'DELETE' }),
 };

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2,7 +2,9 @@ export interface Session {
   id: string;
   cwd: string;
   summary?: string;
-  status: 'running' | 'idle' | 'exited';
+  name?: string;
+  tags?: string[];
+  status: 'running' | 'active' | 'idle' | 'exited';
   createdAt: string;
   updatedAt: string;
   pid?: number;


### PR DESCRIPTION
- Editable session names (pencil icon)
- Color-coded tags with add/remove (tag icon)
- Active status detection (events.jsonl mtime < 2min)
- updatedAt uses last interaction time, not session creation
- Polling-based live session watcher
- Server-side metadata stored in ~/.copilot-remote/session-meta.json
- API: PATCH /sessions/:id/meta, POST/DELETE /sessions/:id/tags