### PR TITLE
🐛 Fix dark text in chat input

### DIFF
--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -173,7 +173,7 @@ export function ChatView({ session, messages, onSend, onResume }: Props) {
                 background: 'transparent',
                 border: 'none',
                 outline: 'none',
-                color: 'inherit',
+                color: '#e6edf3',
                 fontSize: 14,
                 lineHeight: '20px',
               }}


### PR DESCRIPTION
Use explicit #e6edf3 color instead of inherit for native input element