### PR TITLE
🐛 Fix session name color in chat header

### DIFF
--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -85,10 +85,10 @@ export function ChatView({ session, messages, onSend, onResume }: Props) {
       {/* Session header */}
       <Box sx={{ p: 2, borderBottom: '1px solid', borderColor: 'border.default', display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
         <Box sx={{ flex: 1, overflow: 'hidden' }}>
-          <Text sx={{ fontWeight: 'bold', fontSize: 1, color: 'fg.default', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          <Text sx={{ fontWeight: 'bold', fontSize: 2, color: '#e6edf3', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {session.name || session.summary || session.id.slice(0, 12)}
           </Text>
-          <Text sx={{ color: 'fg.muted', fontSize: 0 }}>{session.cwd}</Text>
+          <Text sx={{ color: '#8b949e', fontSize: 0 }}>{session.cwd}</Text>
         </Box>
         <Label variant={isLive ? 'success' : 'secondary'}>
           {isRunning ? 'running' : isActive ? 'active' : 'ended'}

--- a/web/src/components/MessageBubble.tsx
+++ b/web/src/components/MessageBubble.tsx
@@ -41,12 +41,8 @@ export const MessageBubble = memo(function MessageBubble({ message }: Props) {
             : 'border.default',
         }}
       >
-        <Box sx={{ fontSize: 1, color: 'fg.default', '& p': { m: 0, mb: 1 }, '& p:last-child': { mb: 0 }, '& pre': { bg: 'canvas.inset', p: 2, borderRadius: 2, overflow: 'auto', fontSize: 0 }, '& code': { bg: 'canvas.inset', px: 1, borderRadius: 1, fontSize: '85%' } }}>
-          {!isUser && (
-            <Text sx={{ fontSize: '11px', color: 'fg.muted', fontWeight: 'bold', mr: 1 }}>
-              {isSystem ? '⚙️' : '🤖'}
-            </Text>
-          )}
+        <Box sx={{ fontSize: 1, color: '#e6edf3', '& p': { m: 0, mb: 1 }, '& p:last-child': { mb: 0 }, '& p:first-of-type': { display: 'inline' }, '& pre': { bg: 'canvas.inset', p: 2, borderRadius: 2, overflow: 'auto', fontSize: 0 }, '& code': { bg: 'canvas.inset', px: 1, borderRadius: 1, fontSize: '85%' } }}>
+          {!isUser && <span style={{ fontSize: '12px', marginRight: 4, verticalAlign: 'middle' }}>{isSystem ? '⚙️' : '🤖'}</span>}
           <ReactMarkdown>{message.content}</ReactMarkdown>
         </Box>
         <Text sx={{ fontSize: '10px', color: 'fg.muted', display: 'block', textAlign: isUser ? 'right' : 'left', mt: '2px' }}>


### PR DESCRIPTION
Use explicit hex colors instead of Primer tokens.