### PR TITLE
🐛 Fix dark mode text colors across entire app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="dark" data-dark-theme="dark_dimmed">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#0d1117" />
     <title>Copilot Remote</title>
+    <style>
+      html, body { margin: 0; padding: 0; background: #1c2128; color: #adbac7; }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,7 +5,7 @@ import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <ThemeProvider colorMode="night">
+    <ThemeProvider colorMode="night" nightScheme="dark_dimmed">
       <BaseStyles>
         <App />
       </BaseStyles>


### PR DESCRIPTION
Root cause: missing data-color-mode and data-dark-theme attributes on html element. Primer CSS variables were defaulting to light mode.