### PR TITLE
🐛 Fix GroupHeading missing as prop

### DIFF
--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -109,7 +109,7 @@ export function SessionList({ sessions, loading, error, activeId, onSelect, onNe
 
       <ActionList>
         <ActionList.Group>
-          <ActionList.GroupHeading sx={{ fontSize: '11px', fontWeight: 600, color: 'fg.muted', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+          <ActionList.GroupHeading as="h3" sx={{ fontSize: '11px', fontWeight: 600, color: 'fg.muted', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
             ⚡ Copilot
           </ActionList.GroupHeading>
         {sessions.map(session => (


### PR DESCRIPTION
Adds `as="h3"` to ActionList.GroupHeading to fix Primer invariant error.