### PR TITLE
🐛 Fix message sending + collapsible provider groups

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -142,7 +142,11 @@ wss.on('connection', (ws, req) => {
           break;
         case 'input':
           if (msg.sessionId && msg.text) {
-            sessionManager.sendInput(msg.sessionId, msg.text);
+            const sent = sessionManager.sendInput(msg.sessionId, msg.text);
+            if (!sent) {
+              // Not managed — resume with the prompt
+              sessionManager.createSession({ resume: msg.sessionId, prompt: msg.text });
+            }
           }
           break;
 

--- a/server/src/session-manager.ts
+++ b/server/src/session-manager.ts
@@ -36,6 +36,13 @@ class SessionManager extends EventEmitter {
   async createSession(opts: { prompt?: string; cwd?: string; resume?: string }): Promise<Session> {
     const id = opts.resume || uuidv4();
 
+    // Kill existing managed process if any
+    const existing = this.sessions.get(id);
+    if (existing?.proc) {
+      try { existing.proc.kill(); } catch {}
+      existing.proc = null;
+    }
+
     const args: string[] = [];
     if (opts.resume) {
       args.push('--resume', opts.resume);
@@ -128,7 +135,13 @@ class SessionManager extends EventEmitter {
 
   sendInput(id: string, text: string): boolean {
     const managed = this.sessions.get(id);
-    if (!managed?.proc?.stdin?.writable) return false;
+    if (!managed) return false;
+
+    // If the process is dead or stdin not writable, re-resume with new prompt
+    if (!managed.proc?.stdin?.writable) {
+      this.createSession({ resume: id, prompt: text });
+      return true;
+    }
 
     managed.proc.stdin.write(text + '\n');
 

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Box, Text, ActionList, Button, Spinner, Label, RelativeTime, TextInput } from '@primer/react';
-import { PlusIcon, SyncIcon, PencilIcon, XIcon, TagIcon } from '@primer/octicons-react';
+import { PlusIcon, SyncIcon, PencilIcon, XIcon, TagIcon, ChevronDownIcon, ChevronRightIcon } from '@primer/octicons-react';
 import { api } from '../lib/api';
 import type { Session } from '../types';
 
@@ -34,6 +34,7 @@ interface Props {
 
 export function SessionList({ sessions, loading, error, activeId, onSelect, onNew, onRefresh, onEditingChange }: Props) {
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [copilotCollapsed, setCopilotCollapsed] = useState(false);
   const [editName, setEditName] = useState('');
   const [addingTagId, setAddingTagId] = useState<string | null>(null);
   const [newTag, setNewTag] = useState('');
@@ -109,10 +110,11 @@ export function SessionList({ sessions, loading, error, activeId, onSelect, onNe
 
       <ActionList>
         <ActionList.Group>
-          <ActionList.GroupHeading as="h3" sx={{ fontSize: '11px', fontWeight: 600, color: 'fg.muted', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-            ⚡ Copilot
+          <ActionList.GroupHeading as="h3" sx={{ fontSize: '11px', fontWeight: 600, color: 'fg.muted', textTransform: 'uppercase', letterSpacing: '0.5px', cursor: 'pointer', userSelect: 'none' }} onClick={() => setCopilotCollapsed(!copilotCollapsed)}>
+            {copilotCollapsed ? <ChevronRightIcon size={12} /> : <ChevronDownIcon size={12} />}{' '}
+            ⚡ Copilot ({sessions.length})
           </ActionList.GroupHeading>
-        {sessions.map(session => (
+        {!copilotCollapsed && sessions.map(session => (
           <ActionList.Item
             key={session.id}
             active={session.id === activeId}
@@ -202,7 +204,7 @@ export function SessionList({ sessions, loading, error, activeId, onSelect, onNe
             </Box>
           </ActionList.Item>
         ))}
-        {!loading && sessions.length === 0 && (
+        {!copilotCollapsed && !loading && sessions.length === 0 && (
           <Text sx={{ color: 'fg.muted', fontSize: 1, p: 3, textAlign: 'center', display: 'block' }}>
             No sessions found
           </Text>


### PR DESCRIPTION
- Fix: sendInput re-resumes session when process stdin not writable
- Fix: WebSocket auto-resumes unmanaged sessions with prompt
- Feature: Collapsible Copilot group in sidebar with chevron + count
- Cleans up stale managed processes before re-resuming