### PR TITLE
✨ Sidebar polish: active count + reactive mobile

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,7 +38,13 @@ export default function App() {
     }
   }, [connected]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const isMobile = window.innerWidth < 768;
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
+
+  useEffect(() => {
+    const onResize = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
 
   const handleSelectSession = useCallback((id: string) => {
     if (activeSessionId) unsubscribe(activeSessionId);

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -112,7 +112,10 @@ export function SessionList({ sessions, loading, error, activeId, onSelect, onNe
         <ActionList.Group>
           <ActionList.GroupHeading as="h3" sx={{ fontSize: '11px', fontWeight: 600, color: 'fg.muted', textTransform: 'uppercase', letterSpacing: '0.5px', cursor: 'pointer', userSelect: 'none' }} onClick={() => setCopilotCollapsed(!copilotCollapsed)}>
             {copilotCollapsed ? <ChevronRightIcon size={12} /> : <ChevronDownIcon size={12} />}{' '}
-            ⚡ Copilot ({sessions.length})
+            ⚡ Copilot{' '}
+            <span style={{ fontWeight: 400 }}>
+              {sessions.filter(s => s.status === 'running' || s.status === 'active').length}/{sessions.length}
+            </span>
           </ActionList.GroupHeading>
         {!copilotCollapsed && sessions.map(session => (
           <ActionList.Item


### PR DESCRIPTION
- Show active/total session count in Copilot group header (e.g. 1/14)
- Make isMobile reactive to window resize via useEffect listener