### PR TITLE
✨ ACP streaming integration + watcher deduplication

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { URL } from 'url';
 import { getOrCreateToken, authMiddleware, validateWsToken } from './auth.js';
 import { sessionManager } from './session-manager.js';
+import { acpManager } from './acp-manager.js';
 import { listHistoricalSessions, getSessionDetail, getSessionMessages } from './session-store.js';
 import { getAllMeta, updateMeta, addTag, removeTag } from './session-meta.js';
 import type { WsMessage, WsServerMessage } from './types.js';
@@ -103,12 +104,17 @@ app.delete('/api/sessions/:id', (req, res) => {
   res.json({ killed });
 });
 
-app.post('/api/sessions/:id/send', (req, res) => {
+app.post('/api/sessions/:id/send', async (req, res) => {
   const { text } = req.body;
   if (!text) { res.status(400).json({ error: 'text required' }); return; }
-  const sent = sessionManager.sendInput(req.params.id, text);
-  if (!sent) { res.status(404).json({ error: 'Session not running' }); return; }
-  res.json({ sent: true });
+  try {
+    await acpManager.sendPrompt(req.params.id, text);
+    res.json({ sent: true, via: 'acp' });
+  } catch {
+    const sent = sessionManager.sendInput(req.params.id, text);
+    if (!sent) { res.status(404).json({ error: 'Session not running' }); return; }
+    res.json({ sent: true, via: 'pty' });
+  }
 });
 
 // WebSocket
@@ -142,11 +148,15 @@ wss.on('connection', (ws, req) => {
           break;
         case 'input':
           if (msg.sessionId && msg.text) {
-            const sent = sessionManager.sendInput(msg.sessionId, msg.text);
-            if (!sent) {
-              // Not managed — resume with the prompt
-              sessionManager.createSession({ resume: msg.sessionId, prompt: msg.text });
-            }
+            // Prefer ACP for streaming
+            acpManager.sendPrompt(msg.sessionId, msg.text).catch((err) => {
+              console.error(`[ACP] Prompt failed for ${msg.sessionId?.slice(0, 8)}: ${err.message}`);
+              // Fall back to session-manager (PTY/resume)
+              const sent = sessionManager.sendInput(msg.sessionId!, msg.text!);
+              if (!sent) {
+                sessionManager.createSession({ resume: msg.sessionId!, prompt: msg.text! });
+              }
+            });
           }
           break;
 
@@ -187,7 +197,26 @@ sessionManager.on('message', (sessionId: string, message: any) => {
 import { watchSessionEvents } from './session-watcher.js';
 
 const sessionWatcher = watchSessionEvents((sessionId, message) => {
+  // Skip broadcasting watcher events for sessions with active ACP connections (dedup)
+  if (acpManager.hasSession(sessionId)) return;
   broadcast(sessionId, { type: 'message', sessionId, message });
+});
+
+// ACP streaming events → WebSocket broadcast
+acpManager.on('chunk', (sessionId: string, text: string) => {
+  broadcast(sessionId, { type: 'stream', sessionId, text, timestamp: new Date().toISOString() });
+});
+
+acpManager.on('tool', (sessionId: string, tool: any) => {
+  broadcast(sessionId, { type: 'tool', sessionId, tool, timestamp: new Date().toISOString() });
+});
+
+acpManager.on('turn_complete', (sessionId: string, stopReason: string) => {
+  broadcast(sessionId, { type: 'turn_complete', sessionId, stopReason, timestamp: new Date().toISOString() });
+});
+
+acpManager.on('error', (sessionId: string, err: Error) => {
+  broadcast(sessionId, { type: 'error', sessionId, error: err.message, timestamp: new Date().toISOString() });
 });
 
 // Start

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -30,7 +30,7 @@ export interface WsMessage {
 }
 
 export interface WsServerMessage {
-  type: 'output' | 'status' | 'sessions' | 'message' | 'error';
+  type: 'output' | 'status' | 'sessions' | 'message' | 'error' | 'stream' | 'tool' | 'turn_complete';
   sessionId?: string;
   data?: string;
   status?: Session['status'];
@@ -38,4 +38,8 @@ export interface WsServerMessage {
   message?: ChatMessage;
   error?: string;
   timestamp?: string;
+  // stream-specific fields
+  text?: string;
+  stopReason?: string;
+  tool?: { title?: string; toolCallId?: string; status?: string };
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { Box, Text } from '@primer/react';
 import { SessionList } from './components/SessionList';
 import { ChatView } from './components/ChatView';
@@ -16,13 +16,14 @@ export default function App() {
   const [messages, setMessages] = useState<Map<string, ChatMessage[]>>(new Map());
   const [showNewSession, setShowNewSession] = useState(false);
   const [showSidebar, setShowSidebar] = useState(true);
+  // Track streaming text accumulation per session
+  const streamBuffers = useRef<Map<string, string>>(new Map());
 
   const handleWsMessage = useCallback((msg: WsMessage) => {
     if (msg.type === 'message' && msg.sessionId && msg.message) {
       setMessages(prev => {
         const next = new Map(prev);
         const list = next.get(msg.sessionId!) || [];
-        // Deduplicate: skip if same role+content already exists (optimistic or watcher duplicate)
         const m = msg.message!;
         const isDup = list.some(existing =>
           existing.role === m.role && existing.content === m.content
@@ -31,6 +32,51 @@ export default function App() {
         next.set(msg.sessionId!, [...list, m]);
         return next;
       });
+    } else if (msg.type === 'stream' && msg.sessionId && msg.text) {
+      // Accumulate streaming text into a "typing" message
+      const sid = msg.sessionId;
+      const buf = (streamBuffers.current.get(sid) || '') + msg.text;
+      streamBuffers.current.set(sid, buf);
+      setMessages(prev => {
+        const next = new Map(prev);
+        const list = next.get(sid) || [];
+        // Update or create the streaming message (last message with id 'streaming-<sid>')
+        const streamId = `streaming-${sid}`;
+        const streamMsg: ChatMessage = {
+          id: streamId,
+          role: 'copilot',
+          content: buf,
+          timestamp: new Date().toISOString(),
+        };
+        const idx = list.findIndex(m => m.id === streamId);
+        if (idx >= 0) {
+          const updated = [...list];
+          updated[idx] = streamMsg;
+          next.set(sid, updated);
+        } else {
+          next.set(sid, [...list, streamMsg]);
+        }
+        return next;
+      });
+    } else if (msg.type === 'turn_complete' && msg.sessionId) {
+      // Finalize the streaming message with a stable ID
+      const sid = msg.sessionId;
+      const buf = streamBuffers.current.get(sid);
+      streamBuffers.current.delete(sid);
+      if (buf) {
+        setMessages(prev => {
+          const next = new Map(prev);
+          const list = next.get(sid) || [];
+          const streamId = `streaming-${sid}`;
+          const idx = list.findIndex(m => m.id === streamId);
+          if (idx >= 0) {
+            const updated = [...list];
+            updated[idx] = { ...updated[idx], id: `complete-${Date.now()}` };
+            next.set(sid, updated);
+          }
+          return next;
+        });
+      }
     }
   }, []);
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -19,7 +19,7 @@ export interface ChatMessage {
 }
 
 export interface WsMessage {
-  type: 'output' | 'status' | 'sessions' | 'message' | 'error';
+  type: 'output' | 'status' | 'sessions' | 'message' | 'error' | 'stream' | 'tool' | 'turn_complete';
   sessionId?: string;
   data?: string;
   status?: Session['status'];
@@ -27,4 +27,7 @@ export interface WsMessage {
   message?: ChatMessage;
   error?: string;
   timestamp?: string;
+  text?: string;
+  stopReason?: string;
+  tool?: { title?: string; toolCallId?: string; status?: string };
 }


### PR DESCRIPTION
## Changes
- **ACP-first input**: WebSocket `input` and REST `/send` try ACP streaming first, fall back to PTY/resume
- **Real-time streaming**: Server broadcasts `stream` chunks → web accumulates into live copilot message bubble  
- **Turn completion**: `turn_complete` event finalizes streaming message with stable ID
- **Watcher dedup**: Sessions with active ACP connections skip events.jsonl watcher broadcasts
- **New WS types**: `stream`, `tool`, `turn_complete` added to both server and web type definitions

### How it works
1. User sends message → server tries `acpManager.sendPrompt()` (spawns `copilot --acp --allow-all`)
2. Streaming chunks arrive via ACP `sessionUpdate` callback → broadcast as `type: 'stream'` WS messages
3. Web client accumulates chunks into a live-updating message bubble
4. On `turn_complete`, message gets a stable ID (no longer replaced on next stream)
5. If ACP fails, falls back to old PTY/resume path