### PR TITLE
✨ Web terminal with node-pty + xterm.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3189,6 +3189,27 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6375,6 +6396,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -9544,6 +9581,7 @@
       "version": "0.1.0",
       "dependencies": {
         "express": "^5.1.0",
+        "node-pty": "^1.1.0",
         "uuid": "^11.1.0",
         "ws": "^8.18.0",
         "yaml": "^2.7.0"
@@ -9563,6 +9601,9 @@
       "dependencies": {
         "@primer/octicons-react": "^19.0.0",
         "@primer/react": "^37.0.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/xterm": "^6.0.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-markdown": "^9.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -6,19 +6,21 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
-    "build": "tsc"
+    "build": "tsc",
+    "postinstall": "chmod +x ../node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
     "express": "^5.1.0",
+    "node-pty": "^1.1.0",
+    "uuid": "^11.1.0",
     "ws": "^8.18.0",
-    "yaml": "^2.7.0",
-    "uuid": "^11.1.0"
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
-    "@types/ws": "^8.5.13",
-    "@types/uuid": "^10.0.0",
     "@types/node": "^22.0.0",
+    "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.5.13",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { URL } from 'url';
 import { getOrCreateToken, authMiddleware, validateWsToken } from './auth.js';
 import { sessionManager } from './session-manager.js';
 import { acpManager } from './acp-manager.js';
+import { terminalManager } from './terminal-manager.js';
 import { listHistoricalSessions, getSessionDetail, getSessionMessages } from './session-store.js';
 import { getAllMeta, updateMeta, addTag, removeTag } from './session-meta.js';
 import type { WsMessage, WsServerMessage } from './types.js';
@@ -118,7 +119,7 @@ app.post('/api/sessions/:id/send', async (req, res) => {
 });
 
 // WebSocket
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({ noServer: true });
 
 // Track subscriptions
 const subscriptions = new Map<WebSocket, Set<string>>();
@@ -221,6 +222,103 @@ acpManager.on('turn_complete', (sessionId: string, stopReason: string) => {
 
 acpManager.on('error', (sessionId: string, err: Error) => {
   broadcast(sessionId, { type: 'error', sessionId, error: err.message, timestamp: new Date().toISOString() });
+});
+
+// Terminal REST endpoints
+app.get('/api/terminals', (_req, res) => {
+  res.json(terminalManager.list());
+});
+
+app.post('/api/terminals', (req, res) => {
+  try {
+    const { cwd } = req.body || {};
+    const id = `term-${Date.now()}`;
+    const terminal = terminalManager.create(id, cwd);
+    res.status(201).json({ id: terminal.id, cwd: terminal.cwd, createdAt: terminal.createdAt });
+  } catch (err: any) {
+    console.error('[Terminal] Failed to create:', err.message);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.delete('/api/terminals/:id', (req, res) => {
+  const killed = terminalManager.destroy(req.params.id);
+  res.json({ killed });
+});
+
+// Terminal WebSocket — separate path for raw PTY I/O
+const termWss = new WebSocketServer({ noServer: true });
+
+server.on('upgrade', (req, socket, head) => {
+  const url = new URL(req.url || '', `http://localhost:${PORT}`);
+  const token = url.searchParams.get('token') || undefined;
+
+  if (!validateWsToken(token)) {
+    socket.destroy();
+    return;
+  }
+
+  if (url.pathname === '/ws/terminal') {
+    termWss.handleUpgrade(req, socket, head, (ws) => {
+      termWss.emit('connection', ws, req);
+    });
+  } else if (url.pathname === '/ws') {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, req);
+    });
+  } else {
+    socket.destroy();
+  }
+});
+
+termWss.on('connection', (ws, req) => {
+  const url = new URL(req.url || '', `http://localhost:${PORT}`);
+  const termId = url.searchParams.get('id') || undefined;
+
+  if (!termId) {
+    ws.close(4002, 'Terminal id required');
+    return;
+  }
+
+  // Create terminal if it doesn't exist
+  terminalManager.create(termId);
+
+  // Forward PTY output → WebSocket
+  const onData = (id: string, data: string) => {
+    if (id === termId && ws.readyState === WebSocket.OPEN) {
+      ws.send(data);
+    }
+  };
+  const onExit = (id: string, exitCode: number) => {
+    if (id === termId && ws.readyState === WebSocket.OPEN) {
+      ws.send(`\r\n[Process exited with code ${exitCode}]\r\n`);
+      ws.close(1000);
+    }
+  };
+
+  terminalManager.on('data', onData);
+  terminalManager.on('exit', onExit);
+
+  // WebSocket input → PTY
+  ws.on('message', (raw) => {
+    const msg = raw.toString();
+    // Check for resize messages (JSON)
+    try {
+      const parsed = JSON.parse(msg);
+      if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
+        terminalManager.resize(termId, parsed.cols, parsed.rows);
+        return;
+      }
+    } catch {
+      // Not JSON — raw terminal input
+    }
+    terminalManager.write(termId, msg);
+  });
+
+  ws.on('close', () => {
+    terminalManager.removeListener('data', onData);
+    terminalManager.removeListener('exit', onExit);
+  });
 });
 
 // Start

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -1,0 +1,108 @@
+import { EventEmitter } from 'events';
+import * as pty from 'node-pty';
+import { homedir } from 'os';
+
+interface Terminal {
+  id: string;
+  pty: pty.IPty;
+  cwd: string;
+  createdAt: string;
+}
+
+class TerminalManager extends EventEmitter {
+  private terminals = new Map<string, Terminal>();
+
+  create(id: string, cwd?: string): Terminal {
+    if (this.terminals.has(id)) {
+      return this.terminals.get(id)!;
+    }
+
+    const shell = process.env.SHELL || '/bin/zsh';
+    const resolvedCwd = cwd || homedir();
+
+    let term: pty.IPty;
+    try {
+      term = pty.spawn(shell, [], {
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24,
+        cwd: resolvedCwd,
+        env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
+      });
+    } catch {
+      // Fallback: try /bin/bash, then /bin/sh
+      try {
+        term = pty.spawn('/bin/bash', [], {
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 24,
+          cwd: resolvedCwd,
+          env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
+        });
+      } catch {
+        term = pty.spawn('/bin/sh', [], {
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 24,
+          cwd: resolvedCwd,
+          env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
+        });
+      }
+    }
+
+    const terminal: Terminal = {
+      id,
+      pty: term,
+      cwd: resolvedCwd,
+      createdAt: new Date().toISOString(),
+    };
+
+    term.onData((data) => {
+      this.emit('data', id, data);
+    });
+
+    term.onExit(({ exitCode }) => {
+      this.emit('exit', id, exitCode);
+      this.terminals.delete(id);
+    });
+
+    this.terminals.set(id, terminal);
+    return terminal;
+  }
+
+  write(id: string, data: string): boolean {
+    const t = this.terminals.get(id);
+    if (!t) return false;
+    t.pty.write(data);
+    return true;
+  }
+
+  resize(id: string, cols: number, rows: number): boolean {
+    const t = this.terminals.get(id);
+    if (!t) return false;
+    t.pty.resize(cols, rows);
+    return true;
+  }
+
+  destroy(id: string): boolean {
+    const t = this.terminals.get(id);
+    if (!t) return false;
+    t.pty.kill();
+    this.terminals.delete(id);
+    return true;
+  }
+
+  get(id: string) {
+    return this.terminals.get(id);
+  }
+
+  list() {
+    return Array.from(this.terminals.values()).map(t => ({
+      id: t.id,
+      cwd: t.cwd,
+      createdAt: t.createdAt,
+    }));
+  }
+}
+
+export const terminalManager = new TerminalManager();

--- a/web/package.json
+++ b/web/package.json
@@ -9,8 +9,11 @@
     "preview": "vite preview --host"
   },
   "dependencies": {
-    "@primer/react": "^37.0.0",
     "@primer/octicons-react": "^19.0.0",
+    "@primer/react": "^37.0.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/xterm": "^6.0.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-markdown": "^9.0.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,9 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { Box, Text } from '@primer/react';
+import { Box, Text, UnderlineNav } from '@primer/react';
+import { TerminalIcon, CommentDiscussionIcon } from '@primer/octicons-react';
 import { SessionList } from './components/SessionList';
 import { ChatView } from './components/ChatView';
+import { TerminalView } from './components/TerminalView';
 import { ConnectionStatus } from './components/ConnectionStatus';
 import { NewSessionDialog } from './components/NewSessionDialog';
 import { useWebSocket } from './hooks/useWebSocket';
@@ -10,6 +12,7 @@ import { api } from './lib/api';
 import type { WsMessage, ChatMessage } from './types';
 
 export default function App() {
+  const [activeTab, setActiveTab] = useState<'sessions' | 'terminal'>('sessions');
   const [activeSessionId, setActiveSessionId] = useState<string | null>(
     () => localStorage.getItem('copilot-remote-active-session')
   );
@@ -161,45 +164,69 @@ export default function App() {
 
   return (
     <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column', bg: 'canvas.default' }}>
-      <Box sx={{ p: 3, borderBottom: '1px solid', borderColor: 'border.default', display: 'flex', alignItems: 'center', gap: 2 }}>
-        <Text sx={{ fontWeight: 'bold', fontSize: 2, color: 'fg.default' }}>⚡ Copilot Remote</Text>
-        <Box sx={{ flex: 1 }} />
-        <ConnectionStatus connected={connected} />
+      <Box sx={{ px: 3, pt: 2, borderBottom: '1px solid', borderColor: 'border.default' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+          <Text sx={{ fontWeight: 'bold', fontSize: 2, color: 'fg.default' }}>⚡ Copilot Remote</Text>
+          <Box sx={{ flex: 1 }} />
+          <ConnectionStatus connected={connected} />
+        </Box>
+        <UnderlineNav aria-label="Main navigation">
+          <UnderlineNav.Item
+            aria-current={activeTab === 'sessions' ? 'page' : undefined}
+            onClick={() => setActiveTab('sessions')}
+            icon={CommentDiscussionIcon}
+          >
+            Sessions
+          </UnderlineNav.Item>
+          <UnderlineNav.Item
+            aria-current={activeTab === 'terminal' ? 'page' : undefined}
+            onClick={() => setActiveTab('terminal')}
+            icon={TerminalIcon}
+          >
+            Terminal
+          </UnderlineNav.Item>
+        </UnderlineNav>
       </Box>
 
-      <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
-        {(!isMobile || showSidebar) && (
-          <Box sx={{ width: isMobile ? '100%' : 300, minWidth: isMobile ? undefined : 250, borderRight: isMobile ? 'none' : '1px solid', borderColor: 'border.default', overflowY: 'auto' }}>
-            <SessionList
-              sessions={sessions}
-              loading={loading}
-              error={error}
-              activeId={activeSessionId}
-              onSelect={handleSelectSession}
-              onNew={handleNewSession}
-              onRefresh={refresh}
-              onEditingChange={setPaused}
-            />
-          </Box>
-        )}
-        {(!isMobile || !showSidebar) && (
-          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0, minWidth: 0 }}>
-            {activeSession ? (
-              <ChatView
-                session={activeSession}
-                messages={activeMessages}
-                onSend={handleSendMessage}
-                onResume={handleResumeSession}
-                onBack={isMobile ? () => setShowSidebar(true) : undefined}
+      {activeTab === 'sessions' ? (
+        <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
+          {(!isMobile || showSidebar) && (
+            <Box sx={{ width: isMobile ? '100%' : 300, minWidth: isMobile ? undefined : 250, borderRight: isMobile ? 'none' : '1px solid', borderColor: 'border.default', overflowY: 'auto' }}>
+              <SessionList
+                sessions={sessions}
+                loading={loading}
+                error={error}
+                activeId={activeSessionId}
+                onSelect={handleSelectSession}
+                onNew={handleNewSession}
+                onRefresh={refresh}
+                onEditingChange={setPaused}
               />
-            ) : (
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1 }}>
-                <Text sx={{ color: 'fg.muted', fontSize: 1 }}>Select a session or create a new one</Text>
-              </Box>
-            )}
-          </Box>
-        )}
-      </Box>
+            </Box>
+          )}
+          {(!isMobile || !showSidebar) && (
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0, minWidth: 0 }}>
+              {activeSession ? (
+                <ChatView
+                  session={activeSession}
+                  messages={activeMessages}
+                  onSend={handleSendMessage}
+                  onResume={handleResumeSession}
+                  onBack={isMobile ? () => setShowSidebar(true) : undefined}
+                />
+              ) : (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1 }}>
+                  <Text sx={{ color: 'fg.muted', fontSize: 1 }}>Select a session or create a new one</Text>
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
+      ) : (
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <TerminalView onBack={isMobile ? () => setActiveTab('sessions') : undefined} />
+        </Box>
+      )}
 
       {showNewSession && (
         <NewSessionDialog

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { Box, IconButton, Text } from '@primer/react';
+import { PlusIcon, TrashIcon, ArrowLeftIcon } from '@primer/octicons-react';
+import '@xterm/xterm/css/xterm.css';
+
+interface Props {
+  onBack?: () => void;
+}
+
+export function TerminalView({ onBack }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const [termId, setTermId] = useState<string | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  const connect = useCallback((id: string) => {
+    // Clean up existing
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    if (termRef.current) {
+      termRef.current.dispose();
+      termRef.current = null;
+    }
+
+    const token = localStorage.getItem('copilot-remote-token') || '';
+    const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.hostname}:3001`;
+    const wsUrl = serverUrl.replace(/^http/, 'ws');
+
+    const term = new Terminal({
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily: '"Cascadia Code", "Fira Code", "SF Mono", monospace',
+      theme: {
+        background: '#0d1117',
+        foreground: '#e6edf3',
+        cursor: '#58a6ff',
+        cursorAccent: '#0d1117',
+        selectionBackground: '#264f78',
+        black: '#484f58',
+        red: '#ff7b72',
+        green: '#3fb950',
+        yellow: '#d29922',
+        blue: '#58a6ff',
+        magenta: '#bc8cff',
+        cyan: '#39d353',
+        white: '#b1bac4',
+        brightBlack: '#6e7681',
+        brightRed: '#ffa198',
+        brightGreen: '#56d364',
+        brightYellow: '#e3b341',
+        brightBlue: '#79c0ff',
+        brightMagenta: '#d2a8ff',
+        brightCyan: '#56d364',
+        brightWhite: '#f0f6fc',
+      },
+      allowTransparency: true,
+      scrollback: 5000,
+    });
+
+    const fitAddon = new FitAddon();
+    const webLinksAddon = new WebLinksAddon();
+    term.loadAddon(fitAddon);
+    term.loadAddon(webLinksAddon);
+
+    termRef.current = term;
+    fitAddonRef.current = fitAddon;
+
+    if (containerRef.current) {
+      containerRef.current.innerHTML = '';
+      term.open(containerRef.current);
+      setTimeout(() => fitAddon.fit(), 50);
+    }
+
+    const ws = new WebSocket(`${wsUrl}/ws/terminal?token=${token}&id=${id}`);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setConnected(true);
+      // Send initial size
+      ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+    };
+
+    ws.onmessage = (e) => {
+      term.write(e.data);
+    };
+
+    ws.onclose = () => {
+      setConnected(false);
+      term.write('\r\n\x1b[33m[Disconnected]\x1b[0m\r\n');
+    };
+
+    // Forward keystrokes to server
+    term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(data);
+      }
+    });
+
+    // Forward resize
+    term.onResize(({ cols, rows }) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'resize', cols, rows }));
+      }
+    });
+  }, []);
+
+  // Create a terminal on mount
+  useEffect(() => {
+    const token = localStorage.getItem('copilot-remote-token') || '';
+    const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol}//${window.location.hostname}:3001`;
+
+    fetch(`${serverUrl}/api/terminals`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+      .then(r => r.json())
+      .then(data => {
+        setTermId(data.id);
+        connect(data.id);
+      })
+      .catch(err => console.error('Failed to create terminal:', err));
+
+    return () => {
+      wsRef.current?.close();
+      termRef.current?.dispose();
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Handle window resize
+  useEffect(() => {
+    const handleResize = () => {
+      if (fitAddonRef.current) {
+        try { fitAddonRef.current.fit(); } catch {}
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const handleNewTerminal = useCallback(() => {
+    const token = localStorage.getItem('copilot-remote-token') || '';
+    const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol}//${window.location.hostname}:3001`;
+
+    fetch(`${serverUrl}/api/terminals`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+      .then(r => r.json())
+      .then(data => {
+        if (termId) {
+          // Destroy old terminal
+          fetch(`${serverUrl}/api/terminals/${termId}`, {
+            method: 'DELETE',
+            headers: { 'Authorization': `Bearer ${token}` },
+          }).catch(() => {});
+        }
+        setTermId(data.id);
+        connect(data.id);
+      })
+      .catch(err => console.error('Failed to create terminal:', err));
+  }, [termId, connect]);
+
+  const handleDestroyTerminal = useCallback(() => {
+    if (!termId) return;
+    const token = localStorage.getItem('copilot-remote-token') || '';
+    const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol}//${window.location.hostname}:3001`;
+
+    fetch(`${serverUrl}/api/terminals/${termId}`, {
+      method: 'DELETE',
+      headers: { 'Authorization': `Bearer ${token}` },
+    }).catch(() => {});
+
+    wsRef.current?.close();
+    termRef.current?.dispose();
+    termRef.current = null;
+    setTermId(null);
+    setConnected(false);
+  }, [termId]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Header */}
+      <Box sx={{
+        px: 3, py: 2,
+        borderBottom: '1px solid', borderColor: 'border.default',
+        display: 'flex', alignItems: 'center', gap: 2,
+      }}>
+        {onBack && (
+          <IconButton
+            icon={ArrowLeftIcon}
+            aria-label="Back"
+            variant="invisible"
+            size="small"
+            onClick={onBack}
+          />
+        )}
+        <Text sx={{ fontWeight: 'bold', fontSize: 1, color: 'fg.default' }}>
+          Terminal
+        </Text>
+        <Box sx={{
+          width: 8, height: 8, borderRadius: '50%',
+          bg: connected ? 'success.fg' : 'danger.fg',
+        }} />
+        <Box sx={{ flex: 1 }} />
+        <IconButton
+          icon={PlusIcon}
+          aria-label="New terminal"
+          variant="invisible"
+          size="small"
+          onClick={handleNewTerminal}
+        />
+        <IconButton
+          icon={TrashIcon}
+          aria-label="Close terminal"
+          variant="invisible"
+          size="small"
+          onClick={handleDestroyTerminal}
+        />
+      </Box>
+
+      {/* Terminal container */}
+      <Box
+        ref={containerRef}
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          p: 1,
+          bg: '#0d1117',
+          '& .xterm': { height: '100%' },
+          '& .xterm-viewport': { overflow: 'hidden !important' },
+        }}
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Web Terminal

Adds a full interactive terminal accessible from the web UI (and phone PWA). Uses node-pty on the server and xterm.js on the client.

### Architecture
```
Phone/Browser  <-- WebSocket (raw PTY I/O) -->  Server (node-pty)  <-->  Shell (/bin/zsh)
```

### Changes
- **`server/src/terminal-manager.ts`** — PTY lifecycle: create, write, resize, destroy
- **`server/src/index.ts`** — `/ws/terminal` WebSocket endpoint + REST CRUD + manual upgrade routing
- **`web/src/components/TerminalView.tsx`** — xterm.js terminal with GitHub dark theme, fit addon, web links
- **`web/src/App.tsx`** — Tab navigation: Sessions | Terminal (Primer UnderlineNav)

### Testing
- Created terminal via REST, connected via WebSocket, ran `echo hello-from-web` — output appeared correctly
- Shell fallback chain: zsh → bash → sh (handles different environments)