### PR TITLE
✨ Multi-tab tiled terminals with tmux mouse scroll

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -298,14 +298,20 @@ termWss.on('connection', (ws, req) => {
       ws.close(1000);
     }
   };
+  // Forward command name changes (for tab labels)
+  const onCommand = (id: string, cmd: string) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'command', id, command: cmd }));
+    }
+  };
 
   terminalManager.on('data', onData);
   terminalManager.on('exit', onExit);
+  terminalManager.on('command', onCommand);
 
   // WebSocket input → PTY
   ws.on('message', (raw) => {
     const msg = raw.toString();
-    // Check for resize messages (JSON)
     try {
       const parsed = JSON.parse(msg);
       if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
@@ -321,6 +327,7 @@ termWss.on('connection', (ws, req) => {
   ws.on('close', () => {
     terminalManager.removeListener('data', onData);
     terminalManager.removeListener('exit', onExit);
+    terminalManager.removeListener('command', onCommand);
   });
 });
 

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -8,10 +8,11 @@ interface Terminal {
   pty: pty.IPty;
   cwd: string;
   createdAt: string;
-  tmuxSession: string; // tmux session name for `tmux attach -t <name>`
+  tmuxSession: string;
+  lastCommand: string;
+  inputBuffer: string;
 }
 
-// Check if tmux is available
 const TMUX_PATH = (() => {
   try { return execSync('which tmux', { encoding: 'utf8' }).trim(); } catch { return null; }
 })();
@@ -25,13 +26,17 @@ class TerminalManager extends EventEmitter {
     }
 
     const resolvedCwd = cwd || homedir();
-    // Use a short, readable tmux session name
     const tmuxName = `cr-${id.replace('term-', '')}`;
 
     let term: pty.IPty;
     if (TMUX_PATH) {
-      // Spawn inside tmux so the user can `tmux attach -t <name>` from their laptop
-      term = pty.spawn(TMUX_PATH, ['new-session', '-s', tmuxName, '-x', '80', '-y', '24'], {
+      // Spawn inside tmux with mouse, aggressive-resize, window-size latest
+      term = pty.spawn(TMUX_PATH, [
+        'new-session', '-s', tmuxName, '-x', '80', '-y', '24',
+        ';', 'set', '-g', 'mouse', 'on',
+        ';', 'set', '-g', 'window-size', 'latest',
+        ';', 'set', '-g', 'aggressive-resize', 'on',
+      ], {
         name: 'xterm-256color',
         cols: 80,
         rows: 24,
@@ -39,7 +44,6 @@ class TerminalManager extends EventEmitter {
         env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
       });
     } else {
-      // Fallback: bare shell (no sharing)
       const shell = process.env.SHELL || '/bin/zsh';
       term = pty.spawn(shell, [], {
         name: 'xterm-256color',
@@ -56,6 +60,8 @@ class TerminalManager extends EventEmitter {
       cwd: resolvedCwd,
       createdAt: new Date().toISOString(),
       tmuxSession: TMUX_PATH ? tmuxName : '',
+      lastCommand: '',
+      inputBuffer: '',
     };
 
     term.onData((data) => {
@@ -75,6 +81,22 @@ class TerminalManager extends EventEmitter {
     const t = this.terminals.get(id);
     if (!t) return false;
     t.pty.write(data);
+
+    // Track commands: accumulate input, capture on Enter
+    for (const ch of data) {
+      if (ch === '\r' || ch === '\n') {
+        const cmd = t.inputBuffer.trim();
+        if (cmd) {
+          t.lastCommand = cmd;
+          this.emit('command', id, cmd);
+        }
+        t.inputBuffer = '';
+      } else if (ch === '\x7f' || ch === '\b') {
+        t.inputBuffer = t.inputBuffer.slice(0, -1);
+      } else if (ch.charCodeAt(0) >= 32) {
+        t.inputBuffer += ch;
+      }
+    }
     return true;
   }
 
@@ -103,6 +125,7 @@ class TerminalManager extends EventEmitter {
       cwd: t.cwd,
       createdAt: t.createdAt,
       tmuxSession: t.tmuxSession,
+      lastCommand: t.lastCommand,
     }));
   }
 }

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -3,254 +3,358 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Box, IconButton, Text } from '@primer/react';
-import { PlusIcon, TrashIcon, ArrowLeftIcon } from '@primer/octicons-react';
+import { PlusIcon, XIcon, ArrowLeftIcon, ColumnsIcon } from '@primer/octicons-react';
 import '@xterm/xterm/css/xterm.css';
+
+interface TermTab {
+  id: string;
+  tmuxSession: string;
+  name: string;
+  checked: boolean;
+}
+
+// Mutable refs for each terminal's xterm + ws (not in React state to avoid re-renders)
+const termInstances = new Map<string, {
+  term: Terminal;
+  fitAddon: FitAddon;
+  ws: WebSocket;
+  connected: boolean;
+  container: HTMLDivElement | null;
+}>();
+
+function getServerUrls() {
+  const token = localStorage.getItem('copilot-remote-token') || '';
+  const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol}//${window.location.hostname}:3001`;
+  const wsUrl = serverUrl.replace(/^http/, 'ws');
+  return { token, serverUrl, wsUrl };
+}
+
+const TERM_OPTS: ConstructorParameters<typeof Terminal>[0] = {
+  cursorBlink: true,
+  fontSize: 14,
+  fontFamily: '"Cascadia Code", "Fira Code", "SF Mono", monospace',
+  theme: {
+    background: '#0d1117',
+    foreground: '#e6edf3',
+    cursor: '#58a6ff',
+    cursorAccent: '#0d1117',
+    selectionBackground: '#264f78',
+    black: '#484f58', red: '#ff7b72', green: '#3fb950', yellow: '#d29922',
+    blue: '#58a6ff', magenta: '#bc8cff', cyan: '#39d353', white: '#b1bac4',
+    brightBlack: '#6e7681', brightRed: '#ffa198', brightGreen: '#56d364',
+    brightYellow: '#e3b341', brightBlue: '#79c0ff', brightMagenta: '#d2a8ff',
+    brightCyan: '#56d364', brightWhite: '#f0f6fc',
+  },
+  allowTransparency: true,
+  scrollback: 5000,
+};
 
 interface Props {
   onBack?: () => void;
 }
 
 export function TerminalView({ onBack }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const termRef = useRef<Terminal | null>(null);
-  const wsRef = useRef<WebSocket | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
-  const [termId, setTermId] = useState<string | null>(null);
-  const [tmuxSession, setTmuxSession] = useState<string | null>(null);
-  const [connected, setConnected] = useState(false);
+  const [tabs, setTabs] = useState<TermTab[]>([]);
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const [tileMode, setTileMode] = useState(false);
+  const singleRef = useRef<HTMLDivElement>(null);
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
 
-  const connect = useCallback((id: string) => {
-    // Clean up existing
-    if (wsRef.current) {
-      wsRef.current.close();
-      wsRef.current = null;
-    }
-    if (termRef.current) {
-      termRef.current.dispose();
-      termRef.current = null;
+  const createTermConnection = useCallback((tabId: string, container: HTMLDivElement) => {
+    // Clean up if exists
+    const existing = termInstances.get(tabId);
+    if (existing) {
+      existing.ws?.close();
+      existing.term?.dispose();
+      termInstances.delete(tabId);
     }
 
-    const token = localStorage.getItem('copilot-remote-token') || '';
-    const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.hostname}:3001`;
-    const wsUrl = serverUrl.replace(/^http/, 'ws');
-
-    const term = new Terminal({
-      cursorBlink: true,
-      fontSize: 14,
-      fontFamily: '"Cascadia Code", "Fira Code", "SF Mono", monospace',
-      theme: {
-        background: '#0d1117',
-        foreground: '#e6edf3',
-        cursor: '#58a6ff',
-        cursorAccent: '#0d1117',
-        selectionBackground: '#264f78',
-        black: '#484f58',
-        red: '#ff7b72',
-        green: '#3fb950',
-        yellow: '#d29922',
-        blue: '#58a6ff',
-        magenta: '#bc8cff',
-        cyan: '#39d353',
-        white: '#b1bac4',
-        brightBlack: '#6e7681',
-        brightRed: '#ffa198',
-        brightGreen: '#56d364',
-        brightYellow: '#e3b341',
-        brightBlue: '#79c0ff',
-        brightMagenta: '#d2a8ff',
-        brightCyan: '#56d364',
-        brightWhite: '#f0f6fc',
-      },
-      allowTransparency: true,
-      scrollback: 5000,
-    });
-
+    const { token, wsUrl } = getServerUrls();
+    const term = new Terminal(TERM_OPTS);
     const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon();
     term.loadAddon(fitAddon);
-    term.loadAddon(webLinksAddon);
+    term.loadAddon(new WebLinksAddon());
 
-    termRef.current = term;
-    fitAddonRef.current = fitAddon;
+    container.innerHTML = '';
+    term.open(container);
+    setTimeout(() => { try { fitAddon.fit(); } catch {} }, 50);
 
-    if (containerRef.current) {
-      containerRef.current.innerHTML = '';
-      term.open(containerRef.current);
-      setTimeout(() => fitAddon.fit(), 50);
-    }
-
-    const ws = new WebSocket(`${wsUrl}/ws/terminal?token=${token}&id=${id}`);
-    wsRef.current = ws;
+    const ws = new WebSocket(`${wsUrl}/ws/terminal?token=${token}&id=${tabId}`);
+    const inst = { term, fitAddon, ws, connected: false, container };
+    termInstances.set(tabId, inst);
 
     ws.onopen = () => {
-      setConnected(true);
-      // Send initial size
+      inst.connected = true;
       ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+      setTabs(prev => [...prev]); // trigger re-render for status dot
     };
 
     ws.onmessage = (e) => {
+      try {
+        const parsed = JSON.parse(e.data);
+        if (parsed.type === 'command') {
+          setTabs(prev => prev.map(t => t.id === parsed.id ? { ...t, name: parsed.command } : t));
+          return;
+        }
+      } catch { /* raw terminal data */ }
       term.write(e.data);
     };
 
     ws.onclose = () => {
-      setConnected(false);
+      inst.connected = false;
       term.write('\r\n\x1b[33m[Disconnected]\x1b[0m\r\n');
+      setTabs(prev => [...prev]);
     };
 
-    // Forward keystrokes to server
     term.onData((data) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(data);
-      }
+      if (ws.readyState === WebSocket.OPEN) ws.send(data);
     });
 
-    // Forward resize
     term.onResize(({ cols, rows }) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'resize', cols, rows }));
-      }
+      if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'resize', cols, rows }));
     });
   }, []);
 
-  // Create a terminal on mount
+  const addTab = useCallback(async () => {
+    const { token, serverUrl } = getServerUrls();
+    try {
+      const res = await fetch(`${serverUrl}/api/terminals`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      const newTab: TermTab = {
+        id: data.id,
+        tmuxSession: data.tmuxSession || '',
+        name: `Terminal ${tabsRef.current.length + 1}`,
+        checked: false,
+      };
+      setTabs(prev => [...prev, newTab]);
+      setActiveTabId(data.id);
+    } catch (err) {
+      console.error('Failed to create terminal:', err);
+    }
+  }, []);
+
+  const closeTab = useCallback((id: string) => {
+    const { token, serverUrl } = getServerUrls();
+    const inst = termInstances.get(id);
+    if (inst) {
+      inst.ws?.close();
+      inst.term?.dispose();
+      termInstances.delete(id);
+    }
+    fetch(`${serverUrl}/api/terminals/${id}`, {
+      method: 'DELETE', headers: { 'Authorization': `Bearer ${token}` },
+    }).catch(() => {});
+    setTabs(prev => {
+      const next = prev.filter(t => t.id !== id);
+      if (activeTabId === id) {
+        setActiveTabId(next.length > 0 ? next[next.length - 1].id : null);
+      }
+      return next;
+    });
+  }, [activeTabId]);
+
+  const toggleCheck = useCallback((id: string) => {
+    setTabs(prev => prev.map(t => t.id === id ? { ...t, checked: !t.checked } : t));
+  }, []);
+
+  // Create first tab on mount
   useEffect(() => {
-    const token = localStorage.getItem('copilot-remote-token') || '';
-    const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol}//${window.location.hostname}:3001`;
-
-    fetch(`${serverUrl}/api/terminals`, {
-      method: 'POST',
-      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({}),
-    })
-      .then(r => r.json())
-      .then(data => {
-        setTermId(data.id);
-        setTmuxSession(data.tmuxSession || null);
-        connect(data.id);
-      })
-      .catch(err => console.error('Failed to create terminal:', err));
-
+    addTab();
     return () => {
-      wsRef.current?.close();
-      termRef.current?.dispose();
+      for (const [, inst] of termInstances) {
+        inst.ws?.close();
+        inst.term?.dispose();
+      }
+      termInstances.clear();
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Mount active terminal to single container (non-tile mode)
+  useEffect(() => {
+    if (tileMode || !activeTabId || !singleRef.current) return;
+    const inst = termInstances.get(activeTabId);
+    if (inst && inst.container === singleRef.current) {
+      // Already mounted here — just refit
+      setTimeout(() => { try { inst.fitAddon.fit(); } catch {} }, 50);
+      return;
+    }
+    if (inst) {
+      // Re-mount existing terminal
+      singleRef.current.innerHTML = '';
+      inst.term.open(singleRef.current);
+      inst.container = singleRef.current;
+      setTimeout(() => { try { inst.fitAddon.fit(); } catch {} }, 50);
+      inst.term.focus();
+    } else if (tabs.find(t => t.id === activeTabId)) {
+      // New terminal — connect
+      createTermConnection(activeTabId, singleRef.current);
+    }
+  }, [activeTabId, tileMode, tabs.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle window resize
   useEffect(() => {
     const handleResize = () => {
-      if (fitAddonRef.current) {
-        try { fitAddonRef.current.fit(); } catch {}
+      if (tileMode) {
+        for (const [, inst] of termInstances) {
+          try { inst.fitAddon.fit(); } catch {}
+        }
+      } else {
+        const inst = activeTabId ? termInstances.get(activeTabId) : null;
+        if (inst) try { inst.fitAddon.fit(); } catch {}
       }
     };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  }, [activeTabId, tileMode]);
 
-  const handleNewTerminal = useCallback(() => {
-    const token = localStorage.getItem('copilot-remote-token') || '';
-    const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol}//${window.location.hostname}:3001`;
+  const checkedTabs = tabs.filter(t => t.checked);
+  const hasChecked = checkedTabs.length > 0;
 
-    fetch(`${serverUrl}/api/terminals`, {
-      method: 'POST',
-      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({}),
-    })
-      .then(r => r.json())
-      .then(data => {
-        if (termId) {
-          // Destroy old terminal
-          fetch(`${serverUrl}/api/terminals/${termId}`, {
-            method: 'DELETE',
-            headers: { 'Authorization': `Bearer ${token}` },
-          }).catch(() => {});
-        }
-        setTermId(data.id);
-        setTmuxSession(data.tmuxSession || null);
-        connect(data.id);
-      })
-      .catch(err => console.error('Failed to create terminal:', err));
-  }, [termId, connect]);
+  // Tile ref callback — mount terminal into tile container
+  const tileRefCallback = useCallback((el: HTMLDivElement | null, tabId: string) => {
+    if (!el || !tileMode) return;
+    const inst = termInstances.get(tabId);
+    if (inst) {
+      if (inst.container !== el) {
+        el.innerHTML = '';
+        inst.term.open(el);
+        inst.container = el;
+      }
+      setTimeout(() => { try { inst.fitAddon.fit(); } catch {} }, 100);
+    } else {
+      createTermConnection(tabId, el);
+    }
+  }, [tileMode, createTermConnection]);
 
-  const handleDestroyTerminal = useCallback(() => {
-    if (!termId) return;
-    const token = localStorage.getItem('copilot-remote-token') || '';
-    const serverUrl = localStorage.getItem('copilot-remote-server') || `${window.location.protocol}//${window.location.hostname}:3001`;
+  // Refit tiles when entering tile mode
+  useEffect(() => {
+    if (!tileMode) return;
+    const timer = setTimeout(() => {
+      for (const tab of checkedTabs) {
+        const inst = termInstances.get(tab.id);
+        if (inst) try { inst.fitAddon.fit(); } catch {}
+      }
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [tileMode, checkedTabs.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    fetch(`${serverUrl}/api/terminals/${termId}`, {
-      method: 'DELETE',
-      headers: { 'Authorization': `Bearer ${token}` },
-    }).catch(() => {});
-
-    wsRef.current?.close();
-    termRef.current?.dispose();
-    termRef.current = null;
-    setTermId(null);
-    setConnected(false);
-  }, [termId]);
+  const tileCols = checkedTabs.length <= 2 ? checkedTabs.length : checkedTabs.length <= 4 ? 2 : 3;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      {/* Header */}
+      {/* Tab bar */}
       <Box sx={{
-        px: 3, py: 2,
+        display: 'flex', alignItems: 'center',
         borderBottom: '1px solid', borderColor: 'border.default',
-        display: 'flex', alignItems: 'center', gap: 2,
+        bg: 'canvas.subtle', minHeight: '36px',
       }}>
         {onBack && (
+          <IconButton icon={ArrowLeftIcon} aria-label="Back" variant="invisible" size="small" sx={{ mx: 1 }} onClick={onBack} />
+        )}
+        <Box sx={{ display: 'flex', flex: 1, overflow: 'auto', minWidth: 0 }}>
+          {tabs.map(tab => {
+            const inst = termInstances.get(tab.id);
+            const isConnected = inst?.connected ?? false;
+            return (
+              <Box
+                key={tab.id}
+                sx={{
+                  display: 'flex', alignItems: 'center', gap: 1,
+                  px: 2, py: '5px',
+                  cursor: 'pointer',
+                  borderRight: '1px solid', borderColor: 'border.muted',
+                  bg: !tileMode && tab.id === activeTabId ? 'canvas.default' : 'transparent',
+                  borderBottom: !tileMode && tab.id === activeTabId ? '2px solid' : '2px solid transparent',
+                  borderBottomColor: !tileMode && tab.id === activeTabId ? 'accent.fg' : 'transparent',
+                  ':hover': { bg: 'canvas.default' },
+                  maxWidth: 200, flexShrink: 0,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={tab.checked}
+                  onChange={() => toggleCheck(tab.id)}
+                  onClick={e => e.stopPropagation()}
+                  style={{ margin: 0, cursor: 'pointer' }}
+                />
+                <Box
+                  onClick={() => { if (!tileMode) setActiveTabId(tab.id); }}
+                  sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, overflow: 'hidden' }}
+                >
+                  <Box sx={{ width: 6, height: 6, borderRadius: '50%', flexShrink: 0, bg: isConnected ? 'success.fg' : 'danger.fg' }} />
+                  <Text sx={{ fontSize: '11px', color: 'fg.default', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontFamily: 'mono' }}>
+                    {tab.name}
+                  </Text>
+                </Box>
+                <Box
+                  as="button"
+                  onClick={(e: React.MouseEvent) => { e.stopPropagation(); closeTab(tab.id); }}
+                  sx={{ bg: 'transparent', border: 'none', color: 'fg.muted', cursor: 'pointer', p: 0, display: 'flex', flexShrink: 0, ':hover': { color: 'danger.fg' } }}
+                >
+                  <XIcon size={12} />
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+        {hasChecked && (
           <IconButton
-            icon={ArrowLeftIcon}
-            aria-label="Back"
-            variant="invisible"
+            icon={ColumnsIcon}
+            aria-label={tileMode ? 'Single view' : 'Tile checked terminals'}
+            variant={tileMode ? 'primary' : 'invisible'}
             size="small"
-            onClick={onBack}
+            sx={{ mx: 1, flexShrink: 0 }}
+            onClick={() => setTileMode(!tileMode)}
           />
         )}
-        <Text sx={{ fontWeight: 'bold', fontSize: 1, color: 'fg.default' }}>
-          Terminal
-        </Text>
-        <Box sx={{
-          width: 8, height: 8, borderRadius: '50%',
-          bg: connected ? 'success.fg' : 'danger.fg',
-        }} />
-        {tmuxSession ? (
-          <Text sx={{ fontSize: 0, color: 'fg.muted', fontFamily: 'mono' }}>
-            tmux attach -t {tmuxSession}
-          </Text>
-        ) : termId ? (
-          <Text sx={{ fontSize: 0, color: 'fg.muted', fontFamily: 'mono' }}>
-            {termId}
-          </Text>
-        ) : null}
-        <Box sx={{ flex: 1 }} />
-        <IconButton
-          icon={PlusIcon}
-          aria-label="New terminal"
-          variant="invisible"
-          size="small"
-          onClick={handleNewTerminal}
-        />
-        <IconButton
-          icon={TrashIcon}
-          aria-label="Close terminal"
-          variant="invisible"
-          size="small"
-          onClick={handleDestroyTerminal}
-        />
+        <IconButton icon={PlusIcon} aria-label="New terminal" variant="invisible" size="small" sx={{ mx: 1, flexShrink: 0 }} onClick={addTab} />
       </Box>
 
-      {/* Terminal container */}
-      <Box
-        ref={containerRef}
-        sx={{
-          flex: 1,
-          minHeight: 0,
-          p: 1,
-          bg: '#0d1117',
-          '& .xterm': { height: '100%' },
-          '& .xterm-viewport': { overflow: 'hidden !important' },
-        }}
-      />
+      {/* Terminal area */}
+      {tileMode && hasChecked ? (
+        /* Tile grid */
+        <Box sx={{
+          flex: 1, minHeight: 0, display: 'grid',
+          gridTemplateColumns: `repeat(${tileCols}, 1fr)`,
+          gap: '1px', bg: 'border.default',
+        }}>
+          {checkedTabs.map(tab => (
+            <Box key={tab.id} sx={{ display: 'flex', flexDirection: 'column', bg: '#0d1117', minHeight: 0, overflow: 'hidden' }}>
+              <Box sx={{ px: 2, py: '3px', bg: 'canvas.subtle', borderBottom: '1px solid', borderColor: 'border.muted', display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box sx={{ width: 6, height: 6, borderRadius: '50%', bg: termInstances.get(tab.id)?.connected ? 'success.fg' : 'danger.fg' }} />
+                <Text sx={{ fontSize: '10px', fontFamily: 'mono', color: 'fg.muted', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {tab.name}
+                </Text>
+                {tab.tmuxSession && (
+                  <Text sx={{ fontSize: '9px', color: 'fg.subtle', fontFamily: 'mono', ml: 'auto', flexShrink: 0 }}>
+                    {tab.tmuxSession}
+                  </Text>
+                )}
+              </Box>
+              <Box
+                ref={(el: HTMLDivElement | null) => tileRefCallback(el, tab.id)}
+                sx={{ flex: 1, minHeight: 0, '& .xterm': { height: '100%' }, '& .xterm-viewport': { overflow: 'hidden !important' } }}
+              />
+            </Box>
+          ))}
+        </Box>
+      ) : (
+        /* Single terminal */
+        <Box
+          ref={singleRef}
+          sx={{
+            flex: 1, minHeight: 0, p: 1, bg: '#0d1117',
+            '& .xterm': { height: '100%' },
+            '& .xterm-viewport': { overflow: 'hidden !important' },
+          }}
+        />
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Changes
- **tmux mouse on**: enables trackpad/mouse scrolling in tmux scrollback buffer
- **Command broadcast**: server forwards command events to all terminal WS clients for auto tab naming
- **Multi-tab terminals**: add/close/switch tabs, each with own tmux session and xterm.js instance
- **Tile mode**: check tabs → click tile icon → CSS grid split view of selected terminals
- **Tab name auto-update**: tabs show the last command typed in that terminal
- **Status dots**: green/red connection indicator per tab

## Files changed
- `server/src/terminal-manager.ts` — tmux `mouse on`, `window-size latest`, `aggressive-resize on`
- `server/src/index.ts` — command event listener + broadcast to WS clients
- `web/src/components/TerminalView.tsx` — full rewrite: multi-tab, tile grid, checkbox selection