### PR TITLE
✨ Attach existing tmux sessions + fix ANSI tab names

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -244,6 +244,23 @@ app.post('/api/terminals', (req, res) => {
   }
 });
 
+app.post('/api/terminals/attach', (req, res) => {
+  try {
+    const { tmuxSession } = req.body || {};
+    if (!tmuxSession) return res.status(400).json({ error: 'tmuxSession is required' });
+    const id = `term-${Date.now()}`;
+    const terminal = terminalManager.attach(id, tmuxSession);
+    res.status(201).json({ id: terminal.id, cwd: terminal.cwd, createdAt: terminal.createdAt, tmuxSession: terminal.tmuxSession });
+  } catch (err: any) {
+    console.error('[Terminal] Failed to attach:', err.message);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/tmux-sessions', (_req, res) => {
+  res.json(terminalManager.listTmuxSessions());
+});
+
 app.delete('/api/terminals/:id', (req, res) => {
   const killed = terminalManager.destroy(req.params.id);
   res.json({ killed });

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -77,6 +77,52 @@ class TerminalManager extends EventEmitter {
     return terminal;
   }
 
+  /** Attach to an existing tmux session by name */
+  attach(id: string, tmuxSession: string): Terminal {
+    if (this.terminals.has(id)) return this.terminals.get(id)!;
+    if (!TMUX_PATH) throw new Error('tmux is not installed');
+
+    const term = pty.spawn(TMUX_PATH, [
+      'attach-session', '-t', tmuxSession,
+    ], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: homedir(),
+      env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
+    });
+
+    const terminal: Terminal = {
+      id,
+      pty: term,
+      cwd: homedir(),
+      createdAt: new Date().toISOString(),
+      tmuxSession,
+      lastCommand: '',
+      inputBuffer: '',
+    };
+
+    term.onData((data) => this.emit('data', id, data));
+    term.onExit(({ exitCode }) => {
+      this.emit('exit', id, exitCode);
+      this.terminals.delete(id);
+    });
+
+    this.terminals.set(id, terminal);
+    return terminal;
+  }
+
+  /** List tmux sessions available on the machine */
+  listTmuxSessions(): string[] {
+    if (!TMUX_PATH) return [];
+    try {
+      const out = execSync(`${TMUX_PATH} list-sessions -F "#{session_name}"`, { encoding: 'utf8' });
+      return out.trim().split('\n').filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
   write(id: string, data: string): boolean {
     const t = this.terminals.get(id);
     if (!t) return false;

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -2,8 +2,8 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
-import { Box, IconButton, Text } from '@primer/react';
-import { PlusIcon, XIcon, ArrowLeftIcon, ColumnsIcon } from '@primer/octicons-react';
+import { Box, IconButton, Text, ActionMenu, ActionList } from '@primer/react';
+import { PlusIcon, XIcon, ArrowLeftIcon, ColumnsIcon, LinkIcon } from '@primer/octicons-react';
 import '@xterm/xterm/css/xterm.css';
 
 interface TermTab {
@@ -136,6 +136,47 @@ export function TerminalView({ onBack }: Props) {
       setActiveTabId(data.id);
     } catch (err) {
       console.error('Failed to create terminal:', err);
+    }
+  }, []);
+
+  const [tmuxSessions, setTmuxSessions] = useState<string[]>([]);
+
+  const fetchTmuxSessions = useCallback(async () => {
+    const { token, serverUrl } = getServerUrls();
+    try {
+      const res = await fetch(`${serverUrl}/api/tmux-sessions`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      const data = await res.json();
+      // Filter out sessions already attached in our tabs
+      const attached = new Set(tabsRef.current.map(t => t.tmuxSession));
+      setTmuxSessions((data as string[]).filter(s => !attached.has(s)));
+    } catch (err) {
+      console.error('Failed to fetch tmux sessions:', err);
+      setTmuxSessions([]);
+    }
+  }, []);
+
+  const attachTab = useCallback(async (tmuxSession: string) => {
+    const { token, serverUrl } = getServerUrls();
+    try {
+      const res = await fetch(`${serverUrl}/api/terminals/attach`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tmuxSession }),
+      });
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      const newTab: TermTab = {
+        id: data.id,
+        tmuxSession: data.tmuxSession || tmuxSession,
+        name: tmuxSession,
+        checked: false,
+      };
+      setTabs(prev => [...prev, newTab]);
+      setActiveTabId(data.id);
+    } catch (err) {
+      console.error('Failed to attach tmux session:', err);
     }
   }, []);
 
@@ -313,6 +354,26 @@ export function TerminalView({ onBack }: Props) {
             onClick={() => setTileMode(!tileMode)}
           />
         )}
+        <ActionMenu>
+          <ActionMenu.Anchor>
+            <IconButton icon={LinkIcon} aria-label="Attach tmux session" variant="invisible" size="small" sx={{ flexShrink: 0 }} onClick={fetchTmuxSessions} />
+          </ActionMenu.Anchor>
+          <ActionMenu.Overlay>
+            <ActionList>
+              <ActionList.GroupHeading as="h3">Attach tmux session</ActionList.GroupHeading>
+              {tmuxSessions.length === 0 ? (
+                <ActionList.Item disabled>No sessions found</ActionList.Item>
+              ) : (
+                tmuxSessions.map(s => (
+                  <ActionList.Item key={s} onSelect={() => attachTab(s)}>
+                    <ActionList.LeadingVisual><Text sx={{ fontFamily: 'mono', fontSize: '11px' }}>⬡</Text></ActionList.LeadingVisual>
+                    {s}
+                  </ActionList.Item>
+                ))
+              )}
+            </ActionList>
+          </ActionMenu.Overlay>
+        </ActionMenu>
         <IconButton icon={PlusIcon} aria-label="New terminal" variant="invisible" size="small" sx={{ mx: 1, flexShrink: 0 }} onClick={addTab} />
       </Box>
 


### PR DESCRIPTION
## Changes

### 🐛 Fix ANSI escape codes in tab names
- Skip command tracking when input contains escape sequences (mouse events, arrow keys)
- Prevents raw codes like `[<0;32;18M` from showing as tab names

### ✨ Attach existing tmux sessions from web
- **Server**: `attach()` method spawns `tmux attach-session -t <name>`
- **Server**: `listTmuxSessions()` enumerates all tmux sessions on the machine
- **REST**: `POST /api/terminals/attach` and `GET /api/tmux-sessions`
- **Web**: Link icon button in tab bar opens dropdown of available tmux sessions
- Already-attached sessions are filtered from the list