### PR TITLE
✨ Auto-launch AI CLI (copilot/claude) in new terminals

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -234,14 +234,18 @@ app.get('/api/terminals', (_req, res) => {
 
 app.post('/api/terminals', (req, res) => {
   try {
-    const { cwd } = req.body || {};
+    const { cwd, aiCli } = req.body || {};
     const id = `term-${Date.now()}`;
-    const terminal = terminalManager.create(id, cwd);
+    const terminal = terminalManager.create(id, cwd, aiCli);
     res.status(201).json({ id: terminal.id, cwd: terminal.cwd, createdAt: terminal.createdAt, tmuxSession: terminal.tmuxSession });
   } catch (err: any) {
     console.error('[Terminal] Failed to create:', err.message);
     res.status(500).json({ error: err.message });
   }
+});
+
+app.get('/api/ai-clis', (_req, res) => {
+  res.json(terminalManager.listAiClis());
 });
 
 app.post('/api/terminals/attach', (req, res) => {

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -17,10 +17,24 @@ const TMUX_PATH = (() => {
   try { return execSync('which tmux', { encoding: 'utf8' }).trim(); } catch { return null; }
 })();
 
+/** Detect available AI CLI tools */
+function detectAiClis(): { name: string; path: string }[] {
+  const clis: { name: string; path: string }[] = [];
+  for (const name of ['copilot', 'claude']) {
+    try {
+      const p = execSync(`which ${name}`, { encoding: 'utf8' }).trim();
+      if (p) clis.push({ name, path: p });
+    } catch { /* not installed */ }
+  }
+  return clis;
+}
+
+const AI_CLIS = detectAiClis();
+
 class TerminalManager extends EventEmitter {
   private terminals = new Map<string, Terminal>();
 
-  create(id: string, cwd?: string): Terminal {
+  create(id: string, cwd?: string, aiCli?: string): Terminal {
     if (this.terminals.has(id)) {
       return this.terminals.get(id)!;
     }
@@ -52,6 +66,14 @@ class TerminalManager extends EventEmitter {
         cwd: resolvedCwd,
         env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
       });
+    }
+
+    // Auto-launch AI CLI after shell is ready
+    if (aiCli) {
+      const cli = AI_CLIS.find(c => c.name === aiCli);
+      if (cli) {
+        setTimeout(() => term.write(`${cli.name}\r`), 500);
+      }
     }
 
     const terminal: Terminal = {
@@ -166,6 +188,10 @@ class TerminalManager extends EventEmitter {
 
   get(id: string) {
     return this.terminals.get(id);
+  }
+
+  listAiClis() {
+    return AI_CLIS;
   }
 
   list() {

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -116,20 +116,31 @@ export function TerminalView({ onBack }: Props) {
     });
   }, []);
 
-  const addTab = useCallback(async () => {
+  const [aiClis, setAiClis] = useState<{ name: string; path: string }[]>([]);
+
+  // Fetch available AI CLIs on mount
+  useEffect(() => {
+    const { token, serverUrl } = getServerUrls();
+    fetch(`${serverUrl}/api/ai-clis`, { headers: { 'Authorization': `Bearer ${token}` } })
+      .then(r => r.json())
+      .then(data => setAiClis(data))
+      .catch(() => {});
+  }, []);
+
+  const addTab = useCallback(async (aiCli?: string) => {
     const { token, serverUrl } = getServerUrls();
     try {
       const res = await fetch(`${serverUrl}/api/terminals`, {
         method: 'POST',
         headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ aiCli }),
       });
       const data = await res.json();
       if (data.error) throw new Error(data.error);
       const newTab: TermTab = {
         id: data.id,
         tmuxSession: data.tmuxSession || '',
-        name: `Terminal ${tabsRef.current.length + 1}`,
+        name: aiCli || `Terminal ${tabsRef.current.length + 1}`,
         checked: false,
       };
       setTabs(prev => [...prev, newTab]);
@@ -204,9 +215,20 @@ export function TerminalView({ onBack }: Props) {
     setTabs(prev => prev.map(t => t.id === id ? { ...t, checked: !t.checked } : t));
   }, []);
 
-  // Create first tab on mount
+  // Create first tab on mount — auto-launch first available AI CLI
+  const mountedRef = useRef(false);
   useEffect(() => {
-    addTab();
+    if (mountedRef.current) return;
+    mountedRef.current = true;
+    // Wait for aiClis to load, then create with preferred CLI
+    const { token, serverUrl } = getServerUrls();
+    fetch(`${serverUrl}/api/ai-clis`, { headers: { 'Authorization': `Bearer ${token}` } })
+      .then(r => r.json())
+      .then((clis: { name: string }[]) => {
+        const preferred = clis.length > 0 ? clis[0].name : undefined;
+        addTab(preferred);
+      })
+      .catch(() => addTab());
     return () => {
       for (const [, inst] of termInstances) {
         inst.ws?.close();
@@ -374,7 +396,25 @@ export function TerminalView({ onBack }: Props) {
             </ActionList>
           </ActionMenu.Overlay>
         </ActionMenu>
-        <IconButton icon={PlusIcon} aria-label="New terminal" variant="invisible" size="small" sx={{ mx: 1, flexShrink: 0 }} onClick={addTab} />
+        <ActionMenu>
+          <ActionMenu.Anchor>
+            <IconButton icon={PlusIcon} aria-label="New terminal" variant="invisible" size="small" sx={{ mx: 1, flexShrink: 0 }} />
+          </ActionMenu.Anchor>
+          <ActionMenu.Overlay>
+            <ActionList>
+              <ActionList.GroupHeading as="h3">New terminal</ActionList.GroupHeading>
+              {aiClis.map(cli => (
+                <ActionList.Item key={cli.name} onSelect={() => addTab(cli.name)}>
+                  {cli.name === 'copilot' ? '🤖' : '🧠'} {cli.name}
+                </ActionList.Item>
+              ))}
+              <ActionList.Divider />
+              <ActionList.Item onSelect={() => addTab()}>
+                💻 Shell
+              </ActionList.Item>
+            </ActionList>
+          </ActionMenu.Overlay>
+        </ActionMenu>
       </Box>
 
       {/* Terminal area */}


### PR DESCRIPTION
## Changes

- **Server**: Detects `copilot` and `claude` CLIs at startup via `which`
- **API**: `GET /api/ai-clis` returns available CLIs with name and path
- **API**: `POST /api/terminals` now accepts optional `aiCli` body param
- **Terminal**: When `aiCli` is set, auto-types the command 500ms after shell spawn
- **Web**: `+` button opens ActionMenu showing available AI CLIs (🤖 copilot, 🧠 claude) plus 💻 Shell
- **Web**: First terminal on mount auto-launches the first available AI CLI
- **Web**: Tab names default to chosen CLI name

Both `copilot` and `claude` detected on this system.