### PR TITLE
🐛 Fix tmux attach blank screen + rename Terminal to Bidirectional

### DIFF
--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -104,8 +104,14 @@ class TerminalManager extends EventEmitter {
     if (this.terminals.has(id)) return this.terminals.get(id)!;
     if (!TMUX_PATH) throw new Error('tmux is not installed');
 
+    // Use new-session -t to create a grouped session that shares windows
+    // This avoids blank screen from nested attach and allows independent resize
+    const groupName = `cr-${id.replace('term-', '')}`;
     const term = pty.spawn(TMUX_PATH, [
-      'attach-session', '-t', tmuxSession,
+      'new-session', '-s', groupName, '-t', tmuxSession,
+      ';', 'set', '-g', 'mouse', 'on',
+      ';', 'set', '-g', 'window-size', 'latest',
+      ';', 'set', '-g', 'aggressive-resize', 'on',
     ], {
       name: 'xterm-256color',
       cols: 80,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -196,7 +196,7 @@ export default function App() {
             onClick={() => setActiveTab('terminal')}
             icon={TerminalIcon}
           >
-            Terminal
+            Bidirectional
           </UnderlineNav.Item>
         </UnderlineNav>
       </Box>

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -140,7 +140,7 @@ export function TerminalView({ onBack }: Props) {
       const newTab: TermTab = {
         id: data.id,
         tmuxSession: data.tmuxSession || '',
-        name: aiCli || `Terminal ${tabsRef.current.length + 1}`,
+        name: aiCli || `Shell ${tabsRef.current.length + 1}`,
         checked: false,
       };
       setTabs(prev => [...prev, newTab]);


### PR DESCRIPTION
## Changes

### �� Fix attach blank screen
- `tmux attach-session` caused blank screen due to nested tmux conflict
- Switched to `tmux new-session -s <group> -t <target>` which creates a grouped session sharing windows but with independent view/resize
- Also enables mouse, window-size latest, aggressive-resize on attached sessions

### 📖 Rename
- Top nav: 'Terminal' → 'Bidirectional'
- Default tab name: 'Terminal N' → 'Shell N'