### PR TITLE
🐛 Fix ActionMenu crash and terminal black screen

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#0d1117" />
     <title>Copilot Remote</title>
+    <link rel="preload" href="/fonts/MesloLGS-NF-Regular.ttf" as="font" type="font/ttf" crossorigin />
     <style>
       html, body { margin: 0; padding: 0; background: #1c2128; color: #adbac7; }
     </style>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -237,7 +237,7 @@ export default function App() {
           )}
         </Box>
       ) : (
-        <Box sx={{ flex: 1, minHeight: 0 }}>
+        <Box sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
           <TerminalView onBack={isMobile ? () => setActiveTab('sessions') : undefined} />
         </Box>
       )}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -57,9 +57,20 @@ export function TerminalView({ onBack }: Props) {
   const [tabs, setTabs] = useState<TermTab[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [tileMode, setTileMode] = useState(false);
+  const [fontReady, setFontReady] = useState(false);
   const singleRef = useRef<HTMLDivElement>(null);
   const tabsRef = useRef(tabs);
   tabsRef.current = tabs;
+
+  // Preload terminal font before creating any xterm instances
+  useEffect(() => {
+    document.fonts.load('14px "MesloLGS NF"').then(() => {
+      setFontReady(true);
+    }).catch(() => {
+      // Font not available — proceed with fallback
+      setFontReady(true);
+    });
+  }, []);
 
   const createTermConnection = useCallback((tabId: string, container: HTMLDivElement) => {
     // Clean up if exists
@@ -78,7 +89,9 @@ export function TerminalView({ onBack }: Props) {
 
     container.innerHTML = '';
     term.open(container);
-    setTimeout(() => { try { fitAddon.fit(); } catch {} }, 50);
+    setTimeout(() => {
+      try { fitAddon.fit(); } catch {}
+    }, 50);
 
     const ws = new WebSocket(`${wsUrl}/ws/terminal?token=${token}&id=${tabId}`);
     const inst = { term, fitAddon, ws, connected: false, container };
@@ -266,7 +279,7 @@ export function TerminalView({ onBack }: Props) {
 
   // Mount active terminal to single container (non-tile mode)
   useEffect(() => {
-    if (tileMode || !activeTabId || !singleRef.current) return;
+    if (!fontReady || tileMode || !activeTabId || !singleRef.current) return;
     const inst = termInstances.get(activeTabId);
     if (inst && inst.container === singleRef.current) {
       // Already mounted here — just refit
@@ -284,7 +297,7 @@ export function TerminalView({ onBack }: Props) {
       // New terminal — connect
       createTermConnection(activeTabId, singleRef.current);
     }
-  }, [activeTabId, tileMode, tabs.length]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeTabId, tileMode, tabs.length, fontReady]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle window resize
   useEffect(() => {
@@ -308,7 +321,7 @@ export function TerminalView({ onBack }: Props) {
 
   // Tile ref callback — mount terminal into tile container
   const tileRefCallback = useCallback((el: HTMLDivElement | null, tabId: string) => {
-    if (!el || !tileMode) return;
+    if (!el || !tileMode || !fontReady) return;
     const inst = termInstances.get(tabId);
     if (inst) {
       if (inst.container !== el) {
@@ -320,7 +333,7 @@ export function TerminalView({ onBack }: Props) {
     } else {
       createTermConnection(tabId, el);
     }
-  }, [tileMode, createTermConnection]);
+  }, [tileMode, fontReady, createTermConnection]);
 
   // Refit tiles when entering tile mode
   useEffect(() => {
@@ -405,11 +418,11 @@ export function TerminalView({ onBack }: Props) {
         )}
         <ActionMenu>
           <ActionMenu.Anchor>
-            <IconButton icon={LinkIcon} aria-label="Attach tmux session" variant="invisible" size="small" sx={{ flexShrink: 0 }} onClick={fetchTmuxSessions} />
+            <IconButton icon={LinkIcon} aria-label="Attach tmux session" variant="invisible" size="small" sx={{ flexShrink: 0, color: 'accent.fg' }} onClick={fetchTmuxSessions} />
           </ActionMenu.Anchor>
           <ActionMenu.Overlay>
             <ActionList>
-              <ActionList.GroupHeading as="h3">Attach tmux session</ActionList.GroupHeading>
+              <ActionList.GroupHeading>Attach tmux session</ActionList.GroupHeading>
               {tmuxSessions.length === 0 ? (
                 <ActionList.Item disabled>No sessions found</ActionList.Item>
               ) : (
@@ -425,11 +438,11 @@ export function TerminalView({ onBack }: Props) {
         </ActionMenu>
         <ActionMenu>
           <ActionMenu.Anchor>
-            <IconButton icon={PlusIcon} aria-label="New terminal" variant="invisible" size="small" sx={{ mx: 1, flexShrink: 0 }} />
+            <IconButton icon={PlusIcon} aria-label="New terminal" variant="invisible" size="small" sx={{ mx: 1, flexShrink: 0, color: 'success.fg' }} />
           </ActionMenu.Anchor>
           <ActionMenu.Overlay>
             <ActionList>
-              <ActionList.GroupHeading as="h3">New terminal</ActionList.GroupHeading>
+              <ActionList.GroupHeading>New terminal</ActionList.GroupHeading>
               {aiClis.map(cli => (
                 <ActionList.Item key={cli.name} onSelect={() => addTab(cli.name)}>
                   {cli.name === 'copilot' ? '🤖' : '🧠'} {cli.name}


### PR DESCRIPTION
## Problem
Clicking the + (New terminal) or 🔗 (Attach tmux) buttons caused React to crash with a blank screen. The `ActionList.GroupHeading as="h3"` inside `ActionMenu` triggers a Primer invariant violation.

## Fix
- Remove `as="h3"` from `ActionList.GroupHeading` inside ActionMenu (Primer requires `div` for menu-role headings)
- Add font preloading gate — wait for MesloLGS NF font before creating xterm instances
- Add `display: flex` + `flexDirection: column` to TerminalView wrapper for proper height chain
- Add font preload hint in `index.html`
- Make attach/add button icons more prominent with color styling

## Verified via Chrome CDP
- + menu opens correctly, Shell/copilot/claude options work
- New terminal tab creates with Powerlevel10k prompt rendering
- Attach menu shows tmux sessions
- Zero JS errors after fix