### PR TITLE
✨ Fix tmux dot fill and improve tile grid scaling

### DIFF
--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -48,7 +48,7 @@ class TerminalManager extends EventEmitter {
       term = pty.spawn(TMUX_PATH, [
         'new-session', '-s', tmuxName, '-x', '80', '-y', '24',
         ';', 'set', '-g', 'mouse', 'on',
-        ';', 'set', '-g', 'window-size', 'latest',
+        ';', 'set', '-g', 'window-size', 'largest',
         ';', 'set', '-g', 'aggressive-resize', 'on',
       ], {
         name: 'xterm-256color',
@@ -113,7 +113,7 @@ class TerminalManager extends EventEmitter {
     const term = pty.spawn(TMUX_PATH, [
       'new-session', '-s', groupName, '-t', tmuxSession,
       ';', 'set', '-g', 'mouse', 'on',
-      ';', 'set', '-g', 'window-size', 'latest',
+      ';', 'set', '-g', 'window-size', 'largest',
       ';', 'set', '-g', 'aggressive-resize', 'on',
     ], {
       name: 'xterm-256color',
@@ -184,6 +184,12 @@ class TerminalManager extends EventEmitter {
     const t = this.terminals.get(id);
     if (!t) return false;
     t.pty.resize(cols, rows);
+    // Also force tmux to resize its window to match
+    if (TMUX_PATH && t.tmuxSession) {
+      try {
+        execSync(`${TMUX_PATH} resize-window -t ${t.tmuxSession} -x ${cols} -y ${rows}`, { stdio: 'ignore' });
+      } catch { /* session may not exist or resize not needed */ }
+    }
     return true;
   }
 

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -347,7 +347,11 @@ export function TerminalView({ onBack }: Props) {
     return () => clearTimeout(timer);
   }, [tileMode, checkedTabs.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const tileCols = checkedTabs.length <= 2 ? checkedTabs.length : checkedTabs.length <= 4 ? 2 : 3;
+  // Dynamic grid: 1→1, 2→2, 3-4→2, 5-6→3, 7-9→3, 10+→4
+  const tileCols = checkedTabs.length <= 2 ? checkedTabs.length
+    : checkedTabs.length <= 4 ? 2
+    : checkedTabs.length <= 9 ? 3
+    : 4;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>


### PR DESCRIPTION
- Change tmux window-size from 'latest' to 'largest' to eliminate dot fill when multiple clients are attached
- Add explicit tmux resize-window on terminal resize events  
- Scale tile grid: 1-2 cols match count, 3-4→2 cols, 5-9→3 cols, 10+→4 cols