### PR TITLE
🐛 Fix tile button click reliability

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -514,15 +514,24 @@ export function TerminalView({ onBack }: Props) {
             );
           })}
         </Box>
-        <IconButton
-          icon={AppsIcon}
+        <Box
+          as="button"
           aria-label={tileMode ? 'Single view' : 'Tile checked terminals'}
-          variant={tileMode ? 'primary' : 'invisible'}
-          size="small"
+          title={tileMode ? 'Single view' : 'Tile checked terminals'}
           disabled={!hasChecked}
-          sx={{ mx: 1, flexShrink: 0, opacity: hasChecked ? 1 : 0.3 }}
-          onClick={() => setTileMode(!tileMode)}
-        />
+          onClick={() => setTileMode(m => !m)}
+          sx={{
+            mx: 1, flexShrink: 0, opacity: hasChecked ? 1 : 0.3,
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            width: 28, height: 28, borderRadius: 2, cursor: 'pointer',
+            bg: tileMode ? 'accent.emphasis' : 'transparent',
+            color: tileMode ? 'fg.onEmphasis' : 'fg.muted',
+            border: 'none',
+            ':hover': { bg: tileMode ? 'accent.emphasis' : 'canvas.default', color: 'fg.default' },
+          }}
+        >
+          <AppsIcon size={16} />
+        </Box>
         <ActionMenu>
           <ActionMenu.Anchor>
             <IconButton icon={LinkIcon} aria-label="Attach tmux session" variant="invisible" size="small" sx={{ flexShrink: 0, color: 'accent.fg' }} onClick={fetchTmuxSessions} />

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,15 +1,12 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ThemeProvider, BaseStyles } from '@primer/react';
 import App from './App';
 import './fonts.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <ThemeProvider colorMode="night" nightScheme="dark_dimmed">
-      <BaseStyles>
-        <App />
-      </BaseStyles>
-    </ThemeProvider>
-  </React.StrictMode>,
+  <ThemeProvider colorMode="night" nightScheme="dark_dimmed">
+    <BaseStyles>
+      <App />
+    </BaseStyles>
+  </ThemeProvider>,
 );


### PR DESCRIPTION
- Replace Primer IconButton with plain Box button for tile toggle (onClick wasn't firing reliably on Primer IconButton)
- Remove React.StrictMode which double-invoked effects, breaking xterm imperative DOM mounting