### PR TITLE
🐛 Use COPILOT_GITHUB_TOKEN for coding agent assignment

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,4 +23,4 @@ jobs:
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
GITHUB_TOKEN in Actions lacks permission to assign `copilot-swe-agent[bot]`. Switches to the org-level `COPILOT_GITHUB_TOKEN` secret which has the required permissions.