### PR TITLE
🐛 Switch to ORG_TOKEN for coding agent assignment

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,4 +23,4 @@ jobs:
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:
-      token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      token: ${{ secrets.ORG_TOKEN }}


### PR DESCRIPTION
COPILOT_GITHUB_TOKEN PAT exceeds CNCF enterprise's 366-day lifetime limit. Switches to ORG_TOKEN.