### PR TITLE
🐛 Fix tile grid uneven column sizing

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -610,10 +610,12 @@ export function TerminalView({ onBack }: Props) {
                   </Text>
                 )}
               </Box>
-              <Box
-                ref={(el: HTMLDivElement | null) => tileRefCallback(el, tab.id)}
-                sx={{ flex: 1, minHeight: 0, minWidth: 0, overflow: 'hidden', '& .xterm': { height: '100%', width: '100%' }, '& .xterm-viewport': { overflow: 'hidden !important' }, '& .xterm-screen': { width: '100% !important' } }}
-              />
+              <Box sx={{ flex: 1, position: 'relative', minHeight: 0, minWidth: 0, overflow: 'hidden' }}>
+                <Box
+                  ref={(el: HTMLDivElement | null) => tileRefCallback(el, tab.id)}
+                  sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, overflow: 'hidden', '& .xterm': { height: '100%', width: '100%' }, '& .xterm-viewport': { overflow: 'hidden !important' }, '& .xterm-screen': { width: '100% !important' } }}
+                />
+              </Box>
             </Box>
           ))}
         </Box>


### PR DESCRIPTION
xterm canvas from previous single-view was pushing the first grid cell wider. Uses absolute positioning for xterm containers inside tile cells so they can't influence grid column sizing.