### PR TITLE
🐛 Fix Copilot setup steps and add PR automation

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -1,0 +1,45 @@
+name: Auto-Triage on Copilot Assignment
+
+on:
+  issues:
+    types: [assigned]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    if: github.event.assignee.login == 'Copilot' || contains(github.event.assignee.login, 'copilot')
+    steps:
+      - name: Add triage labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = issue.labels.map(l => l.name);
+            
+            if (!labels.includes('ai-fix-requested')) {
+              core.info('Issue does not have ai-fix-requested label, skipping');
+              return;
+            }
+            
+            core.info(`Copilot assigned to issue #${issue.number}`);
+            
+            const labelsToAdd = [];
+            if (!labels.includes('triage/accepted')) {
+              labelsToAdd.push('triage/accepted');
+            }
+            if (!labels.includes('ai-processing')) {
+              labelsToAdd.push('ai-processing');
+            }
+            
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: labelsToAdd
+              });
+              core.info(`Added labels: ${labelsToAdd.join(', ')}`);
+            }

--- a/.github/workflows/copilot-pr-ready.yml
+++ b/.github/workflows/copilot-pr-ready.yml
@@ -1,0 +1,63 @@
+name: Mark Copilot PRs Ready
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  check_suite:
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  mark-ready:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request_target' &&
+      (github.event.pull_request.user.login == 'copilot-swe-agent[bot]' ||
+       github.event.pull_request.user.login == 'Copilot')
+    steps:
+      - name: Wait for Copilot to finish
+        run: sleep 120
+
+      - name: Check if still draft and mark ready
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ORG_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            
+            if (!pr.data.draft) {
+              core.info('PR is already ready for review');
+              return;
+            }
+            
+            // Check if PR has at least 2 commits (plan + implementation)
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            
+            if (commits.data.length < 2) {
+              core.info('PR only has plan commit, Copilot is still working');
+              return;
+            }
+            
+            core.info(`Marking PR #${context.payload.pull_request.number} as ready for review`);
+            
+            // Use GraphQL to mark as ready (REST API doesn't support this)
+            await github.graphql(`
+              mutation($id: ID!) {
+                markPullRequestReadyForReview(input: { pullRequestId: $id }) {
+                  pullRequest { isDraft }
+                }
+              }
+            `, { id: pr.data.node_id });
+            
+            core.info('PR marked as ready for review');

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,7 +7,7 @@ on: workflow_dispatch
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository
@@ -18,9 +18,12 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install native build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3
+
       - name: Install server dependencies
         working-directory: server
-        run: npm ci
+        run: npm install
 
       - name: Build server
         working-directory: server
@@ -28,7 +31,7 @@ jobs:
 
       - name: Install web dependencies
         working-directory: web
-        run: npm ci
+        run: npm install
 
       - name: Build web
         working-directory: web


### PR DESCRIPTION
## Problem
Copilot PRs are stuck in draft because:
1. `copilot-setup-steps.yml` uses `npm ci` but no `package-lock.json` files exist
2. `node-pty` requires native build tools (build-essential, python3)

## Changes
- **copilot-setup-steps.yml**: `npm ci` → `npm install`, add build tools, increase timeout
- **auto-triage.yml**: Auto-add `triage/accepted` + `ai-processing` labels when Copilot is assigned
- **copilot-pr-ready.yml**: Mark Copilot draft PRs as ready for review after implementation commit