### PR TITLE
🐛 Auto-launch first AI CLI instead of plain shell

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -331,9 +331,8 @@ export function TerminalView({ onBack }: Props) {
             .then(r => r.json())
             .then((clis: { name: string }[]) => {
               if (clis.length > 1) {
-                // Multiple CLIs — don't auto-launch, let user choose from + menu
-                // Create a plain shell tab so there's something visible
-                addTab();
+                // Multiple CLIs — auto-launch the first one (usually copilot)
+                addTab(clis[0].name);
               } else if (clis.length === 1) {
                 addTab(clis[0].name);
               } else {


### PR DESCRIPTION
When multiple AI CLIs are detected, the initial tab now auto-launches the first one (typically `copilot`) instead of opening a plain shell.