### PR TITLE
📖 Update README with terminal/tmux/tile features and add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 KubeStellar Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,42 @@
 # ⚡ Copilot Remote
 
-Control GitHub Copilot CLI from your phone. Start sessions, send prompts, and watch Copilot work — all from a mobile-friendly chat interface over your local network.
+Control AI coding agents from any device. Manage Copilot CLI and Claude Code sessions, launch tiled web terminals with tmux, and stream real-time output — all from a mobile-friendly interface over your local network.
 
 ## How It Works
 
 ```
-┌──────────────┐         local WiFi          ┌──────────────────────┐
-│  📱 Phone    │ ◄── WebSocket + REST ──►    │  💻 Laptop           │
-│  (PWA)       │      :5173 → :3001          │  (Node.js server)    │
-│              │                              │                      │
-│  Chat UI     │                              │  Spawns copilot CLI  │
-│  Session list│                              │  Reads ~/.copilot/   │
-│  Tags/rename │                              │  Live-tails events   │
-└──────────────┘                              └──────────────────────┘
++---------------------+       local WiFi       +-------------------------+
+|  Phone / Browser    |  <-- WebSocket+REST --> |  Laptop                 |
+|  (PWA)              |      :5173 -> :3001     |  (Node.js server)       |
+|                     |                         |                         |
+|  Chat UI            |                         |  Spawns AI CLIs         |
+|  Tiled terminals    |                         |  Manages tmux sessions  |
+|  Session list       |                         |  ACP streaming          |
+|  Tags / rename      |                         |  Reads ~/.copilot/      |
++---------------------+                         +-------------------------+
 ```
 
-The **server** runs on your laptop alongside your Copilot CLI installations. It spawns and manages Copilot processes, reads historical sessions from `~/.copilot/session-state/`, live-tails `events.jsonl` files for real-time updates, and streams everything over WebSocket.
+The **server** runs on your laptop alongside your AI CLI installations (Copilot CLI, Claude Code). It spawns and manages AI processes via ACP streaming, provides interactive web terminals backed by tmux and node-pty, reads historical sessions from `~/.copilot/session-state/`, and streams everything over WebSocket.
 
-The **web app** is a React PWA built with [GitHub Primer](https://primer.style/react/) that you open on your phone. It connects to the server over your local network, provides a responsive mobile-first chat interface, and lets you manage sessions with custom names, tags, and real-time status.
+The **web app** is a React PWA built with [GitHub Primer](https://primer.style/react/) and xterm.js. It connects to the server over your local network, provides a chat interface with full terminal emulation, tiled multi-terminal layouts, and lets you manage sessions with custom names, tags, and real-time status.
 
 ## Features
 
 ### Core
-- **📋 Session Browser** — Lists all Copilot CLI sessions: running (managed), active (detected via filesystem), and historical (from `~/.copilot/session-state/`)
-- **🚀 Start Sessions** — Launch new Copilot sessions with a prompt, working directory, or resume an existing session
+- **📋 Session Browser** — Lists all AI CLI sessions: running (managed), active (detected via filesystem), and historical (from `~/.copilot/session-state/`)
+- **🚀 Start Sessions** — Launch new Copilot or Claude sessions with a prompt, working directory, or resume an existing session
 - **💬 iMessage-style Chat** — Send messages and see responses as compact chat bubbles with markdown rendering, inline 🤖 icons, and short timestamps
-- **⚡ Real-time Streaming** — Live-tails `events.jsonl` files (polling every 1.5s with byte-offset reads) for instant message updates
+- **⚡ ACP Streaming** — Real-time streaming via the Agent Client Protocol with persistent `copilot --acp` processes for multi-turn conversations with live text chunks and tool call status
 - **🔄 Resume Sessions** — Pick up where you left off with `--resume <sessionId>`
+- **🗑️ Delete Sessions** — Remove sessions directly from the session list
+
+### Web Terminals
+- **🖥️ Interactive Terminals** — Full terminal emulation powered by xterm.js and node-pty, with cursor blinking, link detection, and responsive sizing
+- **📐 Tile Mode** — Multiple terminals in a tiled grid layout on desktop, each showing a live xterm.js window with independent focus and keyboard shortcuts
+- **🔗 Tmux Integration** — Terminals automatically run inside tmux sessions (`cr-<id>`) with mouse support, allowing sessions to persist and be reattached
+- **🤖 Auto-launch AI CLI** — Automatically detects installed AI tools (Copilot CLI, Claude Code) and launches them in new terminals
+- **📋 Tmux Copy** — Copy tmux session info from tile headers for easy external attach
+- **⌨️ Keyboard Shortcuts** — Navigate and manage tiles with keyboard shortcuts
 
 ### Organization
 - **🏷️ Session Names** — Rename sessions inline with a tap on the pencil icon
@@ -39,7 +49,7 @@ The **web app** is a React PWA built with [GitHub Primer](https://primer.style/r
 - **🌙 Dark Mode** — Proper dark theme using Primer's `dark_dimmed` scheme with explicit high-contrast colors
 
 ### Reliability
-- **🔁 Auto-reconnect** — WebSocket reconnects automatically with 3-second backoff
+- **🔁 Auto-reconnect** — WebSocket reconnects automatically with 3-second backoff; terminals auto-reconnect on server restart
 - **🔄 Auto-restart** — `start.sh` script keeps both servers alive with infinite restart loops
 - **🔒 Token Auth** — Server generates a random 256-bit token on first run; all API/WebSocket calls require it
 - **🤖 Auto-QA** — GitHub Actions workflow runs hourly quality checks (build, lint, security, a11y, performance) with rotating focus areas
@@ -52,13 +62,14 @@ The **web app** is a React PWA built with [GitHub Primer](https://primer.style/r
 ## Prerequisites
 
 - **Node.js 18+** and **npm 9+**
-- **GitHub Copilot CLI** installed and authenticated (`copilot` command available in PATH)
+- **tmux** installed (`brew install tmux` / `apt install tmux`)
+- **GitHub Copilot CLI** and/or **Claude Code** installed and authenticated
 - Laptop and phone on the **same WiFi network**
 
 ## Installation
 
 ```bash
-git clone https://github.com/clubanderson/copilot-remote.git
+git clone https://github.com/kubestellar/copilot-remote.git
 cd copilot-remote
 npm install
 ```
@@ -138,6 +149,8 @@ copilot-remote/
 │   │   ├── session-store.ts    # Reads ~/.copilot/session-state/ for history
 │   │   ├── session-watcher.ts  # Live-tails events.jsonl with byte-offset reads
 │   │   ├── session-meta.ts     # CRUD for session names/tags in ~/.copilot-remote/
+│   │   ├── terminal-manager.ts # Web terminal + tmux session management
+│   │   ├── acp-manager.ts      # Agent Control Protocol streaming for AI CLIs
 │   │   ├── auth.ts             # Token generation, middleware, WS validation
 │   │   └── types.ts            # Shared TypeScript interfaces
 │   ├── package.json
@@ -150,6 +163,7 @@ copilot-remote/
 │   │   │   ├── SessionList.tsx     # Compact session list with inline rename/tags
 │   │   │   ├── ChatView.tsx        # iMessage-style chat with back navigation
 │   │   │   ├── MessageBubble.tsx   # Memoized message with inline markdown
+│   │   │   ├── TerminalView.tsx    # xterm.js tiled terminal grid with tmux
 │   │   │   ├── NewSessionDialog.tsx# Create/resume session form
 │   │   │   └── ConnectionStatus.tsx# Green/red dot indicator
 │   │   ├── hooks/
@@ -222,9 +236,12 @@ Connect to `/ws?token=<token>` for real-time streaming.
 | Server runtime | Node.js + TypeScript |
 | HTTP framework | Express 5 |
 | WebSocket | ws |
+| Terminal PTY | node-pty |
+| Terminal mux | tmux |
 | Session parsing | yaml (for workspace.yaml), line-by-line events.jsonl |
 | Frontend framework | React 18 |
 | UI components | @primer/react (GitHub's design system) |
+| Terminal emulator | @xterm/xterm |
 | Icons | @primer/octicons-react |
 | Markdown | react-markdown |
 | Build tool | Vite 6 |
@@ -261,6 +278,14 @@ Issues are auto-created in GitHub with labels, reproduction steps, and fix guida
 - [x] Live-tailing of active sessions
 - [x] Auto-restart server script
 - [x] Auto-QA workflow
+- [x] Web terminals with xterm.js + node-pty
+- [x] Tmux integration for persistent terminals
+- [x] Tile mode for multi-terminal grid layout
+- [x] Auto-launch AI CLI (Copilot / Claude)
+- [x] ACP streaming for real-time AI responses
+- [x] Terminal auto-reconnect on server restart
+- [x] Delete sessions from session list
+- [x] Keyboard shortcuts for tile navigation
 - [ ] Multi-user collaborative sessions
 - [ ] Slack integration for team collaboration
 - [ ] Push notifications when sessions need input or complete


### PR DESCRIPTION
Brings the README up to date with all the features added today (~30 PRs):

- **Fixed ASCII art** — removed emoji from code block to fix monospace alignment
- **Updated description** — now reflects multi-AI CLI support (Copilot CLI + Claude Code)
- **Added Web Terminals section** — xterm.js, tile mode, tmux integration, auto-launch AI CLI, keyboard shortcuts
- **Updated project structure** — added terminal-manager.ts, acp-manager.ts, TerminalView.tsx
- **Updated tech stack** — added node-pty, tmux, @xterm/xterm
- **Updated roadmap** — marked 8 newly completed items
- **Added tmux** to prerequisites
- **Updated clone URL** to kubestellar org
- **Added Apache-2.0 LICENSE file**