### PR TITLE
📖 Fix ASCII art right box top border alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Control AI coding agents from any device. Manage Copilot CLI and Claude Code ses
 ## How It Works
 
 ```
-+---------------------+       local WiFi       +-------------------------+
++---------------------+       local WiFi        +-------------------------+
 |  Phone / Browser    |  <-- WebSocket+REST --> |  Laptop                 |
 |  (PWA)              |      :5173 -> :3001     |  (Node.js server)       |
 |                     |                         |                         |


### PR DESCRIPTION
One-space fix: the top border gap was 24 chars but content rows were 25, causing the right box `+` to be shifted left by one character.