### PR TITLE
🐛 Prevent duplicate tabs by deduping tmux sessions

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -252,6 +252,11 @@ app.post('/api/terminals/attach', (req, res) => {
   try {
     const { tmuxSession } = req.body || {};
     if (!tmuxSession) return res.status(400).json({ error: 'tmuxSession is required' });
+    // Return existing terminal for this tmux session if one exists
+    const existing = terminalManager.list().find(t => t.tmuxSession === tmuxSession);
+    if (existing) {
+      return res.status(200).json({ id: existing.id, cwd: existing.cwd, createdAt: existing.createdAt, tmuxSession: existing.tmuxSession });
+    }
     const id = `term-${Date.now()}`;
     const terminal = terminalManager.attach(id, tmuxSession);
     res.status(201).json({ id: terminal.id, cwd: terminal.cwd, createdAt: terminal.createdAt, tmuxSession: terminal.tmuxSession });

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -179,6 +179,13 @@ export function TerminalView({ onBack }: Props) {
         if (inst.reconnectTimer) clearTimeout(inst.reconnectTimer);
         termInstances.delete(tabId);
       }
+      // Delete old terminal from server if ID changed
+      if (newId !== tabId) {
+        fetch(`${serverUrl}/api/terminals/${tabId}`, {
+          method: 'DELETE',
+          headers: { 'Authorization': `Bearer ${token}` },
+        }).catch(() => {});
+      }
 
       // Update tab ID in state
       setTabs(prev => prev.map(t => t.id === tabId ? { ...t, id: newId, tmuxSession: data.tmuxSession || tmuxSession } : t));


### PR DESCRIPTION
**Root cause**: `attemptReconnect` calls `/api/terminals/attach` which creates a new server terminal each time, leaving old ones behind. On page reload, all these duplicates get restored as separate tabs.

**Server fix**: `POST /api/terminals/attach` returns existing terminal if one already exists for the tmux session.

**Client fix**: `attemptReconnect` deletes old terminal from server after reattach. Tab restore deduplicates by tmux session (from PR #78).