### PR TITLE
🐛 Filter attach list to exclude managed sessions

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -267,7 +267,10 @@ app.post('/api/terminals/attach', (req, res) => {
 });
 
 app.get('/api/tmux-sessions', (_req, res) => {
-  res.json(terminalManager.listTmuxSessions());
+  // Filter out sessions already managed by a terminal
+  const managed = new Set(terminalManager.list().map(t => t.tmuxSession));
+  const available = terminalManager.listTmuxSessions().filter(s => !managed.has(s));
+  res.json(available);
 });
 
 app.delete('/api/terminals/:id', (req, res) => {


### PR DESCRIPTION
The 'Attach tmux session' dropdown showed all cr-* sessions (78+), including ones already managed by the server. Now filters those out so only unattached sessions appear.