### PR TITLE
🐛 Filter cr-* sessions from attach dropdown

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -267,9 +267,9 @@ app.post('/api/terminals/attach', (req, res) => {
 });
 
 app.get('/api/tmux-sessions', (_req, res) => {
-  // Filter out sessions already managed by a terminal
+  // Filter out cr-* sessions (copilot-remote's own) and already-managed ones
   const managed = new Set(terminalManager.list().map(t => t.tmuxSession));
-  const available = terminalManager.listTmuxSessions().filter(s => !managed.has(s));
+  const available = terminalManager.listTmuxSessions().filter(s => !managed.has(s) && !s.startsWith('cr-'));
   res.json(available);
 });
 


### PR DESCRIPTION
Copilot-remote's own tmux sessions (cr-*) should not appear in the attach dropdown. Only user-created desktop sessions now show.