### PR TITLE
✨ Auto-discover new tmux sessions as tabs

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -363,6 +363,29 @@ termWss.on('connection', (ws, req) => {
   });
 });
 
+// Auto-discover new non-cr-* tmux sessions and broadcast to terminal WS clients
+let knownTmuxSessions = new Set<string>();
+setInterval(() => {
+  const managed = new Set(terminalManager.list().map(t => t.tmuxSession));
+  const allSessions = terminalManager.listTmuxSessions().filter(s => !s.startsWith('cr-'));
+  const newSessions: string[] = [];
+  for (const s of allSessions) {
+    if (!knownTmuxSessions.has(s) && !managed.has(s)) {
+      newSessions.push(s);
+    }
+  }
+  // Update known set to current reality (remove gone sessions too)
+  knownTmuxSessions = new Set([...allSessions, ...Array.from(managed)]);
+  if (newSessions.length > 0) {
+    const msg = JSON.stringify({ type: 'tmux-discovered', sessions: newSessions });
+    for (const client of termWss.clients) {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(msg);
+      }
+    }
+  }
+}, 3000);
+
 // Start
 server.listen(PORT, '0.0.0.0', () => {
   const token = getOrCreateToken();

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -285,6 +285,43 @@ export function TerminalView({ onBack }: Props) {
     }
   }, []);
 
+  // Auto-discover new non-cr-* tmux sessions and attach them as tabs
+  const knownTmuxRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const { token, serverUrl } = getServerUrls();
+      try {
+        const res = await fetch(`${serverUrl}/api/tmux-sessions`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const sessions: string[] = await res.json();
+        for (const s of sessions) {
+          if (!knownTmuxRef.current.has(s)) {
+            knownTmuxRef.current.add(s);
+            // Auto-attach this newly discovered session
+            const attachRes = await fetch(`${serverUrl}/api/terminals/attach`, {
+              method: 'POST',
+              headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+              body: JSON.stringify({ tmuxSession: s }),
+            });
+            const data = await attachRes.json();
+            if (!data.error) {
+              setTabs(prev => {
+                if (prev.some(t => t.tmuxSession === s)) return prev;
+                return [...prev, { id: data.id, tmuxSession: data.tmuxSession || s, name: s, checked: false }];
+              });
+            }
+          }
+        }
+        // Remove sessions that no longer exist
+        for (const s of knownTmuxRef.current) {
+          if (!sessions.includes(s)) knownTmuxRef.current.delete(s);
+        }
+      } catch {}
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
   const closeTab = useCallback((id: string) => {
     const { token, serverUrl } = getServerUrls();
     const inst = termInstances.get(id);


### PR DESCRIPTION
New non-cr-* tmux sessions are automatically detected and attached as tabs in the web UI within 3 seconds.

**Server**: Polls tmux sessions every 3s, broadcasts new discoveries to terminal WS clients.
**Client**: Polls `/api/tmux-sessions` every 3s, auto-attaches new sessions as tabs.

**Test**: Run `tmux new-session -d -s my-work` and watch it appear as a new tab.