### PR TITLE
✨ Re-adopt orphaned tmux sessions on server restart

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -389,6 +389,9 @@ setInterval(() => {
 // Start
 server.listen(PORT, '0.0.0.0', () => {
   const token = getOrCreateToken();
+  // Re-adopt orphaned cr-* tmux sessions from previous server runs
+  const adopted = terminalManager.reAdoptOrphanedSessions();
+  if (adopted > 0) console.log(`♻️  Re-adopted ${adopted} orphaned tmux session(s)`);
   console.log(`\n🚀 Copilot Remote server running on http://0.0.0.0:${PORT}`);
   console.log(`\n🔑 Auth token: ${token}`);
   console.log(`\n   Use this token to connect from your phone.`);

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -218,6 +218,55 @@ class TerminalManager extends EventEmitter {
       lastCommand: t.lastCommand,
     }));
   }
+
+  /** Re-adopt orphaned cr-* tmux sessions from a previous server run */
+  reAdoptOrphanedSessions(): number {
+    if (!TMUX_PATH) return 0;
+    const sessions = this.listTmuxSessions().filter(s => s.startsWith('cr-'));
+    let adopted = 0;
+    for (const s of sessions) {
+      // Skip if already managed
+      if (Array.from(this.terminals.values()).some(t => t.tmuxSession === s)) continue;
+      const id = `term-${s.replace('cr-', '')}`;
+      try {
+        // Directly attach to the existing session (no grouped session)
+        const envNoTmux = { ...process.env, TERM: 'xterm-256color' } as Record<string, string>;
+        delete envNoTmux.TMUX;
+        const term = pty.spawn(TMUX_PATH, [
+          'attach-session', '-t', s,
+        ], {
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 24,
+          cwd: homedir(),
+          env: envNoTmux,
+        });
+
+        const terminal: Terminal = {
+          id,
+          pty: term,
+          cwd: homedir(),
+          createdAt: new Date().toISOString(),
+          tmuxSession: s,
+          lastCommand: s,  // Use session name so client doesn't treat as stale
+          inputBuffer: '',
+        };
+
+        term.onData((data) => this.emit('data', id, data));
+        term.onExit(({ exitCode }) => {
+          this.emit('exit', id, exitCode);
+          this.terminals.delete(id);
+        });
+
+        this.terminals.set(id, terminal);
+        adopted++;
+        console.log(`[Terminal] Re-adopted orphaned tmux session: ${s}`);
+      } catch (err: any) {
+        console.error(`[Terminal] Failed to re-adopt ${s}: ${err.message}`);
+      }
+    }
+    return adopted;
+  }
 }
 
 export const terminalManager = new TerminalManager();

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -359,13 +359,13 @@ export function TerminalView({ onBack }: Props) {
     fetch(`${serverUrl}/api/terminals`, { headers: { 'Authorization': `Bearer ${token}` } })
       .then(r => r.json())
       .then((existing: { id: string; tmuxSession: string; lastCommand: string }[]) => {
-        // Filter to terminals that have an AI CLI running
-        const withCli = existing.filter(t => t.lastCommand && t.lastCommand !== '');
-        if (withCli.length > 0) {
+        // Restore terminals that have a CLI running OR a tmux session (re-adopted)
+        const restorable = existing.filter(t => (t.lastCommand && t.lastCommand !== '') || t.tmuxSession);
+        if (restorable.length > 0) {
           // Deduplicate by tmux session — keep latest per session, delete extras
-          const bySession = new Map<string, typeof withCli[0]>();
-          const dupes: typeof withCli = [];
-          for (const t of withCli) {
+          const bySession = new Map<string, typeof restorable[0]>();
+          const dupes: typeof restorable = [];
+          for (const t of restorable) {
             const key = t.tmuxSession || t.id;
             if (bySession.has(key)) {
               dupes.push(bySession.get(key)!);
@@ -382,9 +382,8 @@ export function TerminalView({ onBack }: Props) {
           }));
           setTabs(restored);
           setActiveTabId(restored[0].id);
-          // Clean up stale terminals without CLIs + duplicates
-          const toDelete = [...existing.filter(e => !e.lastCommand), ...dupes];
-          for (const t of toDelete) {
+          // Clean up duplicates only (not empty-lastCommand ones — they may be re-adopted)
+          for (const t of dupes) {
             fetch(`${serverUrl}/api/terminals/${t.id}`, {
               method: 'DELETE',
               headers: { 'Authorization': `Bearer ${token}` },


### PR DESCRIPTION
On server restart, orphaned cr-* tmux sessions are automatically re-adopted instead of becoming zombies. Running AI CLIs are preserved across restarts.

**Server**: Scans for cr-* tmux sessions at startup and re-attaches via `tmux attach-session`.
**Client**: Restore logic now keeps terminals with tmuxSession set, not just those with lastCommand.