### PR TITLE
✨ Purge sessions from disk with confirmation

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,7 @@ import { getOrCreateToken, authMiddleware, validateWsToken } from './auth.js';
 import { sessionManager } from './session-manager.js';
 import { acpManager } from './acp-manager.js';
 import { terminalManager } from './terminal-manager.js';
-import { listHistoricalSessions, getSessionDetail, getSessionMessages } from './session-store.js';
+import { listHistoricalSessions, getSessionDetail, getSessionMessages, purgeSession } from './session-store.js';
 import { getAllMeta, updateMeta, addTag, removeTag } from './session-meta.js';
 import type { WsMessage, WsServerMessage } from './types.js';
 
@@ -106,6 +106,12 @@ app.delete('/api/sessions/:id', (req, res) => {
   const killed = sessionManager.killSession(req.params.id);
   updateMeta(req.params.id, { hidden: true });
   res.json({ killed, hidden: true });
+});
+
+app.delete('/api/sessions/:id/purge', (req, res) => {
+  sessionManager.killSession(req.params.id);
+  const deleted = purgeSession(req.params.id);
+  res.json({ deleted });
 });
 
 app.post('/api/sessions/:id/send', async (req, res) => {

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, statSync, rmSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { parse as parseYaml } from 'yaml';
@@ -132,4 +132,18 @@ export function getSessionMessages(sessionId: string): ChatMessage[] {
   }
 
   return messages;
+}
+
+/** Delete a session's directory from disk. Returns true if deleted. */
+export function purgeSession(sessionId: string): boolean {
+  // Validate session ID format to prevent path traversal
+  if (!/^[a-f0-9-]+$/i.test(sessionId)) return false;
+  const sessionDir = join(SESSION_STATE_DIR, sessionId);
+  if (!existsSync(sessionDir)) return false;
+  try {
+    rmSync(sessionDir, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -110,15 +110,21 @@ export default function App() {
   }, [activeSessionId, subscribe, unsubscribe, isMobile]);
 
   const handleDeleteSession = useCallback(async (id: string) => {
+    const confirmed = window.confirm(
+      'This will permanently delete the session files from disk (~/.copilot/session-state/).\n\n' +
+      'If this session is actively running, the CLI process may error or crash.\n\n' +
+      'Continue?'
+    );
+    if (!confirmed) return;
     try {
-      await api.killSession(id);
+      await api.purgeSession(id);
       if (activeSessionId === id) {
         setActiveSessionId(null);
         localStorage.removeItem('copilot-remote-active-session');
       }
       refresh();
     } catch (err) {
-      console.error('Delete failed:', err);
+      console.error('Purge failed:', err);
     }
   }, [activeSessionId, refresh]);
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -40,6 +40,9 @@ export const api = {
   killSession: (id: string) =>
     request<{ killed: boolean }>(`/api/sessions/${id}`, { method: 'DELETE' }),
 
+  purgeSession: (id: string) =>
+    request<{ deleted: boolean }>(`/api/sessions/${id}/purge`, { method: 'DELETE' }),
+
   updateSessionMeta: (id: string, meta: { name?: string; tags?: string[] }) =>
     request<{ name?: string; tags?: string[] }>(`/api/sessions/${id}/meta`, { method: 'PATCH', body: JSON.stringify(meta) }),
 


### PR DESCRIPTION
Trash button now permanently deletes session files from disk with a confirmation dialog warning about active session impact.

- Server: `DELETE /api/sessions/:id/purge` removes session directory
- Client: Confirmation dialog warns about file deletion and active session risk
- Path traversal protection via UUID format validation