### PR TITLE
🐛 Fix browser context menu overlapping tmux right-click

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -105,6 +105,8 @@ export function TerminalView({ onBack }: Props) {
 
     container.innerHTML = '';
     term.open(container);
+    // Suppress browser context menu so tmux right-click menus work
+    term.element?.addEventListener('contextmenu', (e) => e.preventDefault());
     setTimeout(() => {
       try { fitAddon.fit(); } catch {}
     }, 50);


### PR DESCRIPTION
Suppresses the browser's native right-click context menu on the terminal element so tmux's right-click menu displays cleanly without overlap.