### PR TITLE
✨ Auto-remove terminal tabs when process exits

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -332,6 +332,7 @@ termWss.on('connection', (ws, req) => {
   };
   const onExit = (id: string, exitCode: number) => {
     if (id === termId && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'exit', id: termId, exitCode }));
       ws.send(`\r\n[Process exited with code ${exitCode}]\r\n`);
       ws.close(1000);
     }

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -129,6 +129,11 @@ export function TerminalView({ onBack }: Props) {
           setTabs(prev => prev.map(t => t.id === parsed.id ? { ...t, name: parsed.command } : t));
           return;
         }
+        if (parsed.type === 'exit') {
+          // Process exited — mark so onclose doesn't try to reconnect
+          (inst as any).processExited = true;
+          return;
+        }
       } catch { /* raw terminal data */ }
       term.write(e.data);
     };
@@ -136,6 +141,13 @@ export function TerminalView({ onBack }: Props) {
     ws.onclose = () => {
       inst.connected = false;
       setTabs(prev => [...prev]);
+
+      // If the process exited (not just a connection drop), auto-remove the tab after a short delay
+      if ((inst as any).processExited) {
+        term.write('\r\n\x1b[33m[Session ended — closing tab]\x1b[0m\r\n');
+        setTimeout(() => closeTabRef.current(tabId), 2000);
+        return;
+      }
 
       // Auto-reconnect if this tab has a tmux session
       const tab = tabsRef.current.find(t => t.id === tabId);
@@ -345,6 +357,9 @@ export function TerminalView({ onBack }: Props) {
       return next;
     });
   }, [activeTabId]);
+
+  const closeTabRef = useRef(closeTab);
+  closeTabRef.current = closeTab;
 
   const toggleCheck = useCallback((id: string) => {
     setTabs(prev => prev.map(t => t.id === id ? { ...t, checked: !t.checked } : t));


### PR DESCRIPTION
Bidirectional tabs now automatically disappear 2 seconds after the underlying process exits.

- Server sends structured `{type:'exit'}` message before closing WebSocket
- Client distinguishes process exit from connection drop
- Exit: shows 'Session ended' then auto-removes tab
- Connection drop: still triggers reconnect as before