### PR TITLE
🌱 ui: widen terminal tabs to 500px max

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -661,7 +661,7 @@ export function TerminalView({ onBack }: Props) {
                   borderBottom: !tileMode && tab.id === activeTabId ? '2px solid' : (tileMode && tab.id === focusedTileId ? '2px solid' : '2px solid transparent'),
                   borderBottomColor: !tileMode && tab.id === activeTabId ? 'accent.fg' : (tileMode && tab.id === focusedTileId ? 'accent.fg' : 'transparent'),
                   ':hover': { bg: 'canvas.default' },
-                  maxWidth: 300, flexShrink: 0,
+                  maxWidth: 500, flexShrink: 0,
                 }}
               >
                 <input


### PR DESCRIPTION
Increases tab maxWidth from 300px to 500px for better readability.