### PR TITLE
🌱 ui: add 150px minimum width to terminal tabs

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -661,7 +661,7 @@ export function TerminalView({ onBack }: Props) {
                   borderBottom: !tileMode && tab.id === activeTabId ? '2px solid' : (tileMode && tab.id === focusedTileId ? '2px solid' : '2px solid transparent'),
                   borderBottomColor: !tileMode && tab.id === activeTabId ? 'accent.fg' : (tileMode && tab.id === focusedTileId ? 'accent.fg' : 'transparent'),
                   ':hover': { bg: 'canvas.default' },
-                  maxWidth: 500, flexShrink: 0,
+                  maxWidth: 500, minWidth: 150, flexShrink: 0,
                 }}
               >
                 <input


### PR DESCRIPTION
Tabs were only as wide as their content. Added minWidth: 150 so short names like 'alpha' or 'copilot' still get a comfortable tab width.