### PR TITLE
🐛 fix: auto-resize terminals with ResizeObserver

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -571,16 +571,25 @@ export function TerminalView({ onBack }: Props) {
     }
   }, [activeTabId, tileMode, tabs.length, fontReady]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Handle window resize — fit all terminals since visibility:hidden preserves layout
+  // ResizeObserver: auto-fit terminals when their containers resize (initial load, window resize, tile/untile)
   useEffect(() => {
-    const handleResize = () => {
-      for (const [, inst] of termInstances) {
-        try { inst.fitAddon.fit(); } catch {}
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const el = entry.target as HTMLElement;
+        for (const [, inst] of termInstances) {
+          if (inst.container === el) {
+            try { inst.fitAddon.fit(); } catch {}
+            break;
+          }
+        }
       }
-    };
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [tileMode]);
+    });
+    // Observe all current containers
+    for (const [, container] of singleContainerRefs.current) {
+      observer.observe(container);
+    }
+    return () => observer.disconnect();
+  }, [tabs.length, tileMode]);
 
   const checkedTabs = tabs.filter(t => t.checked);
   const hasChecked = checkedTabs.length > 0;


### PR DESCRIPTION
Replaces the window resize event listener with a ResizeObserver on terminal containers. This ensures terminals automatically call fit() whenever their container dimensions change — covering initial load, window resize, and tile/untile transitions.

**Problem:** Terminal didn't fill the viewing area on initial load. Tiling then untiling would fix it because the tile→untile transition triggered a manual fit().

**Fix:** ResizeObserver fires as soon as the container gets its final dimensions, so fit() runs at exactly the right time — no more 50ms guessing with setTimeout.