### PR TITLE
✨ Show last intent in tile headers and tab tooltips

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -289,6 +289,11 @@ app.delete('/api/tmux-sessions/:name', (req, res) => {
   res.json({ killed });
 });
 
+app.get('/api/tmux-sessions/:name/title', (req, res) => {
+  const title = terminalManager.getTmuxPaneTitle(req.params.name);
+  res.json({ title });
+});
+
 // Terminal WebSocket — separate path for raw PTY I/O
 const termWss = new WebSocketServer({ noServer: true });
 

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -172,6 +172,20 @@ class TerminalManager extends EventEmitter {
     }
   }
 
+  /** Get the pane title for a tmux session (set by escape sequences like \033]0;...\007) */
+  getTmuxPaneTitle(sessionName: string): string {
+    if (!TMUX_PATH) return '';
+    try {
+      const out = execSync(
+        `${TMUX_PATH} display-message -t "${sessionName}" -p "#{pane_title}"`,
+        { encoding: 'utf8', timeout: 2000 },
+      );
+      return out.trim();
+    } catch {
+      return '';
+    }
+  }
+
   write(id: string, data: string): boolean {
     const t = this.terminals.get(id);
     if (!t) return false;

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -24,6 +24,7 @@ interface TermTab {
   name: string;
   checked: boolean;
   userRenamed?: boolean;
+  lastIntent?: string;
 }
 
 const termInstances = new Map<string, {
@@ -87,7 +88,7 @@ function uniqueName(baseName: string, existingNames: string[]): string {
   return `${baseName}-${i}`;
 }
 
-const TERM_OPTS: ConstructorParameters<typeof Terminal>[0] = {
+const TERM_OPTS: NonNullable<ConstructorParameters<typeof Terminal>[0]> = {
   cursorBlink: true,
   fontSize: 14,
   fontFamily: '"MesloLGS NF", "Cascadia Code", "Fira Code", "SF Mono", monospace',
@@ -211,6 +212,12 @@ export function TerminalView({ onBack }: Props) {
 
     term.onData((data) => {
       if (ws.readyState === WebSocket.OPEN) ws.send(data);
+    });
+
+    term.onTitleChange((title) => {
+      if (title) {
+        setTabs(prev => prev.map(t => t.id === tabId ? { ...t, lastIntent: title } : t));
+      }
     });
 
     term.onResize(({ cols, rows }) => {
@@ -408,6 +415,29 @@ export function TerminalView({ onBack }: Props) {
         }
       } catch {}
     }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Poll tmux pane titles for all tabs (catches titles set before we connected)
+  useEffect(() => {
+    const fetchTitles = async () => {
+      const { token, serverUrl } = getServerUrls();
+      const current = tabsRef.current;
+      for (const tab of current) {
+        if (!tab.tmuxSession) continue;
+        try {
+          const res = await fetch(`${serverUrl}/api/tmux-sessions/${encodeURIComponent(tab.tmuxSession)}/title`, {
+            headers: { 'Authorization': `Bearer ${token}` },
+          });
+          const { title } = await res.json();
+          if (title && title !== tab.lastIntent) {
+            setTabs(prev => prev.map(t => t.id === tab.id ? { ...t, lastIntent: title } : t));
+          }
+        } catch {}
+      }
+    };
+    fetchTitles();
+    const interval = setInterval(fetchTitles, 5000);
     return () => clearInterval(interval);
   }, []);
 
@@ -717,6 +747,7 @@ export function TerminalView({ onBack }: Props) {
             return (
               <Box
                 key={tab.id}
+                title={tab.lastIntent || tab.name}
                 sx={{
                   display: 'flex', alignItems: 'center', gap: 1,
                   px: 2, py: '5px',
@@ -924,6 +955,11 @@ export function TerminalView({ onBack }: Props) {
                 <span style={{ fontSize: 10, fontFamily: 'monospace', color: focusedTileId === tab.id ? '#ffffff' : '#8b949e', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   {tab.name}
                 </span>
+                {tab.lastIntent && (
+                  <span style={{ fontSize: 9, fontFamily: 'monospace', color: focusedTileId === tab.id ? '#a5d6ff' : '#58a6ff', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontStyle: 'italic' }}>
+                    — {tab.lastIntent}
+                  </span>
+                )}
                 {tab.tmuxSession && (
                   <>
                     <span style={{ fontSize: 9, color: focusedTileId === tab.id ? '#a5d6ff' : '#6e7681', fontFamily: 'monospace', marginLeft: 'auto', flexShrink: 0 }}>


### PR DESCRIPTION
## What

Shows the Copilot CLI's current intent/activity in:
- **Tile title bars** — after the session name, e.g. `copilot-2 — 🤖 Building LLM synthesizer module`
- **Tab tooltips** — hover over any tab to see the last reported intent

## How

- **Client**: Captures terminal title changes via xterm's `onTitleChange` (fired when Copilot CLI calls `report_intent`, which sets the terminal title via escape sequences)
- **Server**: New `GET /api/tmux-sessions/:name/title` endpoint reads the tmux pane title for already-running sessions
- **Polling**: Fetches pane titles every 5s to catch titles set before the WebSocket connected

## Changes

- `server/src/terminal-manager.ts`: Added `getTmuxPaneTitle()` method
- `server/src/index.ts`: Added `GET /api/tmux-sessions/:name/title` endpoint
- `web/src/components/TerminalView.tsx`: Added `lastIntent` to TermTab, `onTitleChange` handler, title polling, tile header display, tab tooltip