### PR TITLE
✨ Show last intent in tile headers and tab tooltips

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -279,6 +279,11 @@ app.get('/api/tmux-sessions', (_req, res) => {
   res.json(available);
 });
 
+app.get('/api/tmux-sessions/:name/title', (req, res) => {
+  const title = terminalManager.getTmuxPaneTitle(req.params.name);
+  res.json({ title });
+});
+
 app.delete('/api/terminals/:id', (req, res) => {
   const killed = terminalManager.destroy(req.params.id);
   res.json({ killed });

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -172,6 +172,19 @@ class TerminalManager extends EventEmitter {
     }
   }
 
+  /** Get the pane title for a tmux session (set by CLI tools via escape sequences) */
+  getTmuxPaneTitle(sessionName: string): string {
+    if (!TMUX_PATH) return '';
+    try {
+      return execSync(
+        `${TMUX_PATH} display-message -t "${sessionName}" -p "#{pane_title}"`,
+        { encoding: 'utf8', timeout: 2000 },
+      ).trim();
+    } catch {
+      return '';
+    }
+  }
+
   write(id: string, data: string): boolean {
     const t = this.terminals.get(id);
     if (!t) return false;

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -24,6 +24,7 @@ interface TermTab {
   name: string;
   checked: boolean;
   userRenamed?: boolean;
+  lastIntent?: string;
 }
 
 const termInstances = new Map<string, {
@@ -137,6 +138,7 @@ export function TerminalView({ onBack }: Props) {
   const [renameValue, setRenameValue] = useState('');
   const singleContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const tileContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const intentRef = useRef<Map<string, string>>(new Map());
   const tabsRef = useRef(tabs);
   tabsRef.current = tabs;
 
@@ -240,6 +242,15 @@ export function TerminalView({ onBack }: Props) {
 
     term.onResize(({ cols, rows }) => {
       if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'resize', cols, rows }));
+    });
+
+    // Capture pane title changes (set by CLI tools like Copilot via \033]0;...\007)
+    term.onTitleChange((title) => {
+      const prev = intentRef.current.get(tabId);
+      if (title && title !== prev) {
+        intentRef.current.set(tabId, title);
+        setTabs(p => p.map(t => t.id === tabId ? { ...t, lastIntent: title } : t));
+      }
     });
   }, []);
 
@@ -569,7 +580,21 @@ export function TerminalView({ onBack }: Props) {
     for (const tab of tabs) {
       const container = singleContainerRefs.current.get(tab.id);
       if (!container) continue;
-      if (termInstances.has(tab.id)) continue;
+      const existing = termInstances.get(tab.id);
+      if (existing) {
+        // If terminal is in the wrong container (returning from tile mode), move it back
+        if (existing.term.element && existing.term.element.parentElement !== container) {
+          existing.term.options.fontSize = 14;
+          container.innerHTML = '';
+          container.appendChild(existing.term.element);
+          existing.container = container;
+          requestAnimationFrame(() => {
+            try { existing.fitAddon.fit(); } catch {}
+            existing.term.refresh(0, existing.term.rows - 1);
+          });
+        }
+        continue;
+      }
       createTermConnection(tab.id, container);
     }
   }, [tabs, fontReady, tileActive, createTermConnection]);
@@ -596,7 +621,11 @@ export function TerminalView({ onBack }: Props) {
         inst.term.open(container);
       }
       inst.container = container;
-      setTimeout(() => { try { inst.fitAddon.fit(); } catch {} }, 50);
+      // Force full redraw after reparenting (element was in detached tile container)
+      setTimeout(() => {
+        try { inst.fitAddon.fit(); } catch {}
+        inst.term.refresh(0, inst.term.rows - 1);
+      }, 50);
       inst.term.focus();
     }
   }, [activeTabId, tileActive, tabs.length, fontReady]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -611,6 +640,30 @@ export function TerminalView({ onBack }: Props) {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [tileMode]);
+
+  // Poll tmux pane titles for intent display (covers titles set before we attached)
+  useEffect(() => {
+    const { serverUrl, token } = getServerUrls();
+    const poll = () => {
+      for (const tab of tabsRef.current) {
+        if (!tab.tmuxSession) continue;
+        fetch(`${serverUrl}/api/tmux-sessions/${encodeURIComponent(tab.tmuxSession)}/title`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        })
+          .then(r => r.json())
+          .then(({ title }: { title: string }) => {
+            if (title && title !== intentRef.current.get(tab.id)) {
+              intentRef.current.set(tab.id, title);
+              setTabs(p => p.map(t => t.id === tab.id ? { ...t, lastIntent: title } : t));
+            }
+          })
+          .catch(() => {});
+      }
+    };
+    poll();
+    const iv = setInterval(poll, 8000);
+    return () => clearInterval(iv);
+  }, [tabs.length]);
 
   const checkedTabs = tabs.filter(t => t.checked);
   const hasChecked = checkedTabs.length > 0;
@@ -745,6 +798,7 @@ export function TerminalView({ onBack }: Props) {
             return (
               <Box
                 key={tab.id}
+                title={tab.lastIntent || tab.name}
                 sx={{
                   display: 'flex', alignItems: 'center', gap: 1,
                   px: 2, py: '5px',
@@ -952,6 +1006,11 @@ export function TerminalView({ onBack }: Props) {
                 <span style={{ fontSize: 10, fontFamily: 'monospace', color: focusedTileId === tab.id ? '#ffffff' : '#8b949e', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   {tab.name}
                 </span>
+                {tab.lastIntent && (
+                  <span style={{ fontSize: 9, fontStyle: 'italic', color: focusedTileId === tab.id ? '#a5d6ff' : '#58a6ff', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    — {tab.lastIntent}
+                  </span>
+                )}
                 {tab.tmuxSession && (
                   <>
                     <span style={{ fontSize: 9, color: focusedTileId === tab.id ? '#a5d6ff' : '#6e7681', fontFamily: 'monospace', marginLeft: 'auto', flexShrink: 0 }}>


### PR DESCRIPTION
## Features
- **Tile headers**: Show current intent (e.g. *🤖 Reviewing PR diff*) in italic blue after tab name
- **Tab tooltips**: Hover any tab to see its current intent
- **Server API**: `GET /api/tmux-sessions/:name/title` reads tmux pane title set by CLI tools via escape sequences
- **Polling**: Fetches titles every 8s for sessions that set their title before we attached

## Bug fixes
- **Tile→single remount**: When exiting tile mode, all terminals are now proactively moved back to single containers — previously only the active tab was moved, causing blank terminals when switching tabs
- **Full refresh after reparent**: Forces xterm redraw after moving element from detached tile container

## Testing (CDP verified)
- ✅ Single view render, tab switching
- ✅ Tab tooltips with intent text
- ✅ Tile headers with intent display  
- ✅ Tab click focuses tile in tile mode
- ✅ Tile→single→switch tabs roundtrip
- ✅ Uncheck all in tile mode → graceful single view fallback