### PR TITLE
✨ Todo dispatcher mode: shared task queue for tiled terminals

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import { acpManager } from './acp-manager.js';
 import { terminalManager } from './terminal-manager.js';
 import { listHistoricalSessions, getSessionDetail, getSessionMessages, purgeSession } from './session-store.js';
 import { getAllMeta, updateMeta, addTag, removeTag } from './session-meta.js';
+import { getTodos, setTodos } from './todo-store.js';
 import type { WsMessage, WsServerMessage } from './types.js';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
@@ -19,7 +20,7 @@ app.use(express.json());
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Headers', 'Authorization, Content-Type');
-  res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
   if (req.method === 'OPTIONS') { res.sendStatus(204); return; }
   next();
 });
@@ -295,6 +296,21 @@ app.delete('/api/tmux-sessions/:name', (req, res) => {
   res.json({ killed });
 });
 
+// Todo queue REST endpoints
+app.get('/api/todos', (_req, res) => {
+  res.json(getTodos());
+});
+
+app.put('/api/todos', (req, res) => {
+  const { items, todoMode } = req.body;
+  if (!Array.isArray(items)) {
+    res.status(400).json({ error: 'items must be an array' });
+    return;
+  }
+  setTodos(items, !!todoMode);
+  res.json({ ok: true });
+});
+
 // Terminal WebSocket — separate path for raw PTY I/O
 const termWss = new WebSocketServer({ noServer: true });
 
@@ -354,10 +370,17 @@ termWss.on('connection', (ws, req) => {
       ws.send(JSON.stringify({ type: 'command', id, command: cmd }));
     }
   };
+  // Forward prompt detection (for todo dispatcher)
+  const onPrompt = (id: string) => {
+    if (id === termId && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'prompt', id: termId }));
+    }
+  };
 
   terminalManager.on('data', onData);
   terminalManager.on('exit', onExit);
   terminalManager.on('command', onCommand);
+  terminalManager.on('prompt', onPrompt);
 
   // WebSocket input → PTY
   ws.on('message', (raw) => {
@@ -366,6 +389,14 @@ termWss.on('connection', (ws, req) => {
       const parsed = JSON.parse(msg);
       if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
         terminalManager.resize(termId, parsed.cols, parsed.rows);
+        return;
+      }
+      if (parsed.type === 'watch-prompt') {
+        terminalManager.watchForPrompt(termId);
+        return;
+      }
+      if (parsed.type === 'unwatch-prompt') {
+        terminalManager.unwatchPrompt(termId);
         return;
       }
     } catch (_parseErr) {
@@ -378,6 +409,7 @@ termWss.on('connection', (ws, req) => {
     terminalManager.removeListener('data', onData);
     terminalManager.removeListener('exit', onExit);
     terminalManager.removeListener('command', onCommand);
+    terminalManager.removeListener('prompt', onPrompt);
   });
 });
 

--- a/server/src/prompt-detector.ts
+++ b/server/src/prompt-detector.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'events';
+
+/** Time (ms) to wait after last PTY output before testing for a shell prompt */
+const PROMPT_IDLE_TIMEOUT_MS = 300;
+
+/** Regex to strip ANSI escape sequences from terminal output */
+const PROMPT_ANSI_STRIP_REGEX = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
+/** Common shell prompt-ending patterns */
+const PROMPT_PATTERNS = [
+  /[$#%>]\s*$/,     // generic endings
+  /\]\$\s*$/,       // bash: user@host:~/dir]$
+  /\]#\s*$/,        // root: user@host:~/dir]#
+  /❯\s*$/,          // starship / modern prompts
+  /➜\s*$/,          // oh-my-zsh robbyrussell
+  /λ\s*$/,          // lambda prompts
+];
+
+/**
+ * Detects when a shell prompt appears after PTY output settles.
+ *
+ * For each watched terminal, accumulates the last line of output.
+ * When output stops for PROMPT_IDLE_TIMEOUT_MS, tests the last line
+ * against common prompt patterns and emits 'prompt' if matched.
+ */
+export class PromptDetector extends EventEmitter {
+  /** Set of terminal IDs actively being watched */
+  private watching = new Set<string>();
+
+  /** Debounce timers per terminal */
+  private timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  /** Last line of output per terminal (for prompt matching) */
+  private lastLines = new Map<string, string>();
+
+  /** Start watching a terminal for prompt return */
+  watchForPrompt(id: string): void {
+    this.watching.add(id);
+    this.lastLines.set(id, '');
+  }
+
+  /** Stop watching a terminal */
+  unwatchPrompt(id: string): void {
+    this.watching.delete(id);
+    this.lastLines.delete(id);
+    const timer = this.timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+    }
+  }
+
+  /** Feed PTY output data for a terminal */
+  feed(id: string, data: string): void {
+    if (!this.watching.has(id)) return;
+
+    // Update last line: split by newlines, keep last non-empty segment
+    const stripped = data.replace(PROMPT_ANSI_STRIP_REGEX, '');
+    const lines = stripped.split(/\r?\n/);
+    const lastSegment = lines[lines.length - 1];
+
+    // If data contains newlines, the last line is a fresh start
+    if (lines.length > 1) {
+      this.lastLines.set(id, lastSegment);
+    } else {
+      // Append to current last line
+      const current = this.lastLines.get(id) || '';
+      this.lastLines.set(id, current + lastSegment);
+    }
+
+    // Reset debounce timer
+    const existingTimer = this.timers.get(id);
+    if (existingTimer) clearTimeout(existingTimer);
+
+    this.timers.set(id, setTimeout(() => {
+      this.timers.delete(id);
+      this.checkForPrompt(id);
+    }, PROMPT_IDLE_TIMEOUT_MS));
+  }
+
+  /** Check if the last line matches a prompt pattern */
+  private checkForPrompt(id: string): void {
+    if (!this.watching.has(id)) return;
+
+    const lastLine = (this.lastLines.get(id) || '').trim();
+    if (!lastLine) return;
+
+    const isPrompt = PROMPT_PATTERNS.some(pattern => pattern.test(lastLine));
+    if (isPrompt) {
+      // Stop watching — prompt detected, item is done
+      this.unwatchPrompt(id);
+      this.emit('prompt', id);
+    }
+  }
+
+  /** Clean up all state for a terminal (e.g., on disconnect) */
+  cleanup(id: string): void {
+    this.unwatchPrompt(id);
+  }
+}

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import * as pty from 'node-pty';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
+import { PromptDetector } from './prompt-detector.js';
 
 interface Terminal {
   id: string;
@@ -33,9 +34,14 @@ const AI_CLIS = detectAiClis();
 
 class TerminalManager extends EventEmitter {
   private terminals = new Map<string, Terminal>();
+  private promptDetector = new PromptDetector();
 
   constructor() {
     super();
+    // Forward prompt events from the detector
+    this.promptDetector.on('prompt', (id: string) => {
+      this.emit('prompt', id);
+    });
     // Set tmux global defaults and hooks so ALL sessions use latest window-size
     // 'latest' sizes the window to the most recently active client, so
     // the web tile renders correctly when active, desktop is fine when active
@@ -103,10 +109,12 @@ class TerminalManager extends EventEmitter {
 
     term.onData((data) => {
       this.emit('data', id, data);
+      this.promptDetector.feed(id, data);
     });
 
     term.onExit(({ exitCode }) => {
       this.emit('exit', id, exitCode);
+      this.promptDetector.cleanup(id);
       this.terminals.delete(id);
     });
 
@@ -151,14 +159,28 @@ class TerminalManager extends EventEmitter {
       inputBuffer: '',
     };
 
-    term.onData((data) => this.emit('data', id, data));
+    term.onData((data) => {
+      this.emit('data', id, data);
+      this.promptDetector.feed(id, data);
+    });
     term.onExit(({ exitCode }) => {
       this.emit('exit', id, exitCode);
+      this.promptDetector.cleanup(id);
       this.terminals.delete(id);
     });
 
     this.terminals.set(id, terminal);
     return terminal;
+  }
+
+  /** Start watching a terminal for shell prompt return (used by todo dispatcher) */
+  watchForPrompt(id: string): void {
+    this.promptDetector.watchForPrompt(id);
+  }
+
+  /** Stop watching a terminal for prompt */
+  unwatchPrompt(id: string): void {
+    this.promptDetector.unwatchPrompt(id);
   }
 
   /** List tmux sessions available on the machine */
@@ -336,9 +358,13 @@ class TerminalManager extends EventEmitter {
           inputBuffer: '',
         };
 
-        term.onData((data) => this.emit('data', id, data));
+        term.onData((data) => {
+          this.emit('data', id, data);
+          this.promptDetector.feed(id, data);
+        });
         term.onExit(({ exitCode }) => {
           this.emit('exit', id, exitCode);
+          this.promptDetector.cleanup(id);
           this.terminals.delete(id);
         });
 

--- a/server/src/todo-store.ts
+++ b/server/src/todo-store.ts
@@ -1,0 +1,46 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const TODO_DIR = join(homedir(), '.copilot-remote');
+const TODO_FILE = join(TODO_DIR, 'todo.json');
+
+export interface TodoItemServer {
+  id: string;
+  description: string;
+  status: 'pending' | 'running' | 'done' | 'failed';
+  assignedTileId: string | null;
+  assignedTileName: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+interface TodoStore {
+  items: TodoItemServer[];
+  todoMode: boolean;
+}
+
+function load(): TodoStore {
+  try {
+    if (existsSync(TODO_FILE)) {
+      return JSON.parse(readFileSync(TODO_FILE, 'utf-8'));
+    }
+  } catch (err) {
+    console.debug('[Todo] Failed to load todo store:', err);
+  }
+  return { items: [], todoMode: false };
+}
+
+function save(store: TodoStore): void {
+  if (!existsSync(TODO_DIR)) mkdirSync(TODO_DIR, { recursive: true });
+  writeFileSync(TODO_FILE, JSON.stringify(store, null, 2));
+}
+
+export function getTodos(): TodoStore {
+  return load();
+}
+
+export function setTodos(items: TodoItemServer[], todoMode: boolean): void {
+  save({ items, todoMode });
+}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -3,7 +3,9 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Box, IconButton, Text, ActionMenu, ActionList } from '@primer/react';
-import { PlusIcon, XIcon, ArrowLeftIcon, AppsIcon, LinkIcon, PencilIcon, TrashIcon } from '@primer/octicons-react';
+import { PlusIcon, XIcon, ArrowLeftIcon, AppsIcon, LinkIcon, PencilIcon, TrashIcon, ListUnorderedIcon } from '@primer/octicons-react';
+import { useTodoDispatcher } from '../hooks/useTodoDispatcher';
+import TodoPanel from './TodoPanel';
 import '@xterm/xterm/css/xterm.css';
 
 /* Constrain xterm inside tile cells */
@@ -90,6 +92,7 @@ function uniqueName(baseName: string, existingNames: string[]): string {
 
 const CHECKED_TILES_KEY = 'copilot-remote-checked-tiles';
 const TILE_MODE_KEY = 'copilot-remote-tile-mode';
+const TODO_PANEL_KEY = 'copilot-remote-show-todo-panel';
 
 /** Load saved checked tmux session names */
 function loadCheckedSessions(): Set<string> {
@@ -136,6 +139,7 @@ export function TerminalView({ onBack }: Props) {
   const [focusedTileId, setFocusedTileId] = useState<string | null>(null);
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
+  const [showTodoPanel, setShowTodoPanel] = useState(() => localStorage.getItem(TODO_PANEL_KEY) === 'true');
   const singleContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const tileContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const intentRef = useRef<Map<string, string>>(new Map());
@@ -146,6 +150,18 @@ export function TerminalView({ onBack }: Props) {
   useEffect(() => {
     localStorage.setItem(TILE_MODE_KEY, String(tileMode));
   }, [tileMode]);
+
+  useEffect(() => {
+    localStorage.setItem(TODO_PANEL_KEY, String(showTodoPanel));
+  }, [showTodoPanel]);
+
+  // Getter for termInstances (passed to hook to avoid stale closure)
+  const getTermInstances = useCallback(() => termInstances, []);
+
+  // Todo dispatcher hook
+  const todoDispatcher = useTodoDispatcher(getTermInstances, tabs);
+  const todoDispatcherRef = useRef(todoDispatcher);
+  todoDispatcherRef.current = todoDispatcher;
 
   useEffect(() => {
     saveCheckedSessions(tabs);
@@ -209,6 +225,11 @@ export function TerminalView({ onBack }: Props) {
           (inst as any).processExited = true;
           return;
         }
+        if (parsed.type === 'prompt') {
+          // Shell prompt returned — notify todo dispatcher
+          todoDispatcherRef.current.onTilePromptReturned(tabId);
+          return;
+        }
       } catch (_parseErr) { /* raw terminal data */ }
       term.write(e.data);
     };
@@ -216,6 +237,9 @@ export function TerminalView({ onBack }: Props) {
     ws.onclose = () => {
       inst.connected = false;
       setTabs(prev => [...prev]);
+
+      // Notify todo dispatcher of disconnection
+      todoDispatcherRef.current.onTileDisconnected(tabId);
 
       // If the process exited (not just a connection drop), auto-remove the tab after a short delay
       if ((inst as any).processExited) {
@@ -775,6 +799,9 @@ export function TerminalView({ onBack }: Props) {
         e.preventDefault();
         if (aiClis.length > 0) addTab(aiClis[0].name);
         else addTab();
+      } else if (mod && e.shiftKey && e.key === 'D') {
+        e.preventDefault();
+        setShowTodoPanel(prev => !prev);
       }
     };
     window.addEventListener('keydown', handler);
@@ -895,6 +922,22 @@ export function TerminalView({ onBack }: Props) {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
           <button
             type="button"
+            aria-label={showTodoPanel ? 'Hide todo queue (⌘⇧D)' : 'Show todo queue (⌘⇧D)'}
+            title={showTodoPanel ? 'Hide todo queue (⌘⇧D)' : 'Show todo queue (⌘⇧D)'}
+            onClick={() => setShowTodoPanel(prev => !prev)}
+            style={{
+              flexShrink: 0,
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              width: 28, height: 28, borderRadius: 6, cursor: 'pointer',
+              backgroundColor: showTodoPanel ? 'var(--bgColor-accent-emphasis, #316dca)' : 'transparent',
+              color: showTodoPanel ? 'var(--fgColor-onEmphasis, #fff)' : 'var(--fgColor-muted, #768390)',
+              border: 'none', padding: 0,
+            }}
+          >
+            <ListUnorderedIcon size={16} />
+          </button>
+          <button
+            type="button"
             aria-label={tileMode ? 'Single view (⌘T)' : 'Tile checked terminals (⌘T)'}
             title={tileMode ? 'Single view (⌘T)' : 'Tile checked terminals (⌘T)'}
             disabled={!hasChecked}
@@ -963,6 +1006,11 @@ export function TerminalView({ onBack }: Props) {
         {/* Spacer to balance centering */}
         <Box sx={{ flex: 1 }} />
       </Box>
+
+      {/* Main content: terminal + optional todo panel */}
+      <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
+      {/* Terminal column */}
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0 }}>
 
       {/* Tmux info bar — always rendered with fixed height to prevent layout jitter */}
       {!tileMode && (
@@ -1064,6 +1112,25 @@ export function TerminalView({ onBack }: Props) {
           ))}
         </Box>
       )}
+
+      </Box>{/* end terminal column */}
+
+      {/* Todo queue panel */}
+      {showTodoPanel && (
+        <TodoPanel
+          items={todoDispatcher.items}
+          todoMode={todoDispatcher.todoMode}
+          tabs={tabs}
+          onAddItem={todoDispatcher.addItem}
+          onRemoveItem={todoDispatcher.removeItem}
+          onRetryItem={todoDispatcher.retryItem}
+          onToggleTodoMode={todoDispatcher.toggleTodoMode}
+          onClearCompleted={todoDispatcher.clearCompleted}
+          onReorderItem={todoDispatcher.reorderItem}
+        />
+      )}
+
+      </Box>{/* end main content flex */}
     </Box>
   );
 }

--- a/web/src/components/TodoPanel.tsx
+++ b/web/src/components/TodoPanel.tsx
@@ -1,0 +1,353 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Box, Text } from '@primer/react';
+import { XIcon, SyncIcon, TrashIcon, ChevronUpIcon, ChevronDownIcon } from '@primer/octicons-react';
+import type { TodoItem } from '../types';
+
+/** Width of the todo panel in pixels */
+const TODO_PANEL_WIDTH_PX = 280;
+
+/** Maximum characters allowed in the todo input */
+const TODO_INPUT_MAX_LENGTH = 500;
+
+/** Status dot colors mapped to Primer-compatible values */
+const STATUS_COLORS: Record<TodoItem['status'], string> = {
+  pending: '#6e7681',   // gray — waiting
+  running: '#d29922',   // yellow — in progress
+  done: '#3fb950',      // green — complete
+  failed: '#f85149',    // red — error
+};
+
+/** Human-readable status labels */
+const STATUS_LABELS: Record<TodoItem['status'], string> = {
+  pending: 'Pending',
+  running: 'Running',
+  done: 'Done',
+  failed: 'Failed',
+};
+
+interface TermTab {
+  id: string;
+  name: string;
+}
+
+interface TodoPanelProps {
+  items: TodoItem[];
+  todoMode: boolean;
+  tabs: TermTab[];
+  onAddItem: (description: string) => void;
+  onRemoveItem: (id: string) => void;
+  onRetryItem: (id: string) => void;
+  onToggleTodoMode: () => void;
+  onClearCompleted: () => void;
+  onReorderItem: (id: string, direction: 'up' | 'down') => void;
+}
+
+export default function TodoPanel({
+  items,
+  todoMode,
+  tabs: _tabs,
+  onAddItem,
+  onRemoveItem,
+  onRetryItem,
+  onToggleTodoMode,
+  onClearCompleted,
+  onReorderItem,
+}: TodoPanelProps) {
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const pendingCount = items.filter(i => i.status === 'pending').length;
+  const runningCount = items.filter(i => i.status === 'running').length;
+  const doneCount = items.filter(i => i.status === 'done').length;
+  const failedCount = items.filter(i => i.status === 'failed').length;
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+    onAddItem(trimmed);
+    setInputValue('');
+    inputRef.current?.focus();
+  }, [inputValue, onAddItem]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    }
+    // Prevent terminal from capturing keystrokes
+    e.stopPropagation();
+  }, [handleSubmit]);
+
+  // Auto-focus input when panel opens
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <Box
+      sx={{
+        width: TODO_PANEL_WIDTH_PX,
+        minWidth: TODO_PANEL_WIDTH_PX,
+        maxWidth: TODO_PANEL_WIDTH_PX,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        borderLeft: '1px solid',
+        borderColor: 'border.default',
+        bg: 'canvas.default',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          px: 2,
+          py: 2,
+          borderBottom: '1px solid',
+          borderColor: 'border.muted',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexShrink: 0,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <span style={{ fontSize: 14 }}>☰</span>
+          <Text sx={{ fontSize: '12px', fontWeight: 600 }}>Todo Queue</Text>
+          {items.length > 0 && (
+            <Text sx={{ fontSize: '10px', color: 'fg.muted' }}>({items.length})</Text>
+          )}
+        </Box>
+        <button
+          type="button"
+          onClick={onToggleTodoMode}
+          title={todoMode ? 'Disable auto-dispatch' : 'Enable auto-dispatch'}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '2px 8px',
+            borderRadius: 10,
+            border: 'none',
+            fontSize: 10,
+            fontWeight: 600,
+            cursor: 'pointer',
+            background: todoMode ? '#238636' : '#30363d',
+            color: todoMode ? '#ffffff' : '#8b949e',
+            transition: 'background 0.15s',
+          }}
+        >
+          {todoMode ? 'ON' : 'OFF'}
+        </button>
+      </Box>
+
+      {/* Input */}
+      <Box sx={{ px: 2, py: 2, borderBottom: '1px solid', borderColor: 'border.muted', flexShrink: 0 }}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Add command..."
+          value={inputValue}
+          onChange={e => setInputValue(e.target.value.slice(0, TODO_INPUT_MAX_LENGTH))}
+          onKeyDown={handleKeyDown}
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            borderRadius: 6,
+            border: '1px solid var(--borderColor-default, #30363d)',
+            background: 'var(--bgColor-default, #0d1117)',
+            color: 'var(--fgColor-default, #e6edf3)',
+            fontSize: 12,
+            fontFamily: 'monospace',
+            outline: 'none',
+            boxSizing: 'border-box',
+          }}
+        />
+        <Text sx={{ fontSize: '10px', color: 'fg.muted', mt: 1, display: 'block' }}>
+          Press Enter to add
+        </Text>
+      </Box>
+
+      {/* Item list */}
+      <Box sx={{ flex: 1, overflowY: 'auto', overflowX: 'hidden' }}>
+        {items.length === 0 ? (
+          <Box sx={{ p: 3, textAlign: 'center' }}>
+            <Text sx={{ fontSize: '11px', color: 'fg.muted', fontStyle: 'italic' }}>
+              No items in queue
+            </Text>
+          </Box>
+        ) : (
+          items.map((item, idx) => (
+            <Box
+              key={item.id}
+              sx={{
+                px: 2,
+                py: '6px',
+                borderBottom: '1px solid',
+                borderColor: 'border.muted',
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '6px',
+                bg: item.status === 'running' ? 'attention.subtle' : 'transparent',
+                ':hover': { bg: 'canvas.subtle' },
+              }}
+            >
+              {/* Status dot */}
+              <span
+                title={STATUS_LABELS[item.status]}
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: STATUS_COLORS[item.status],
+                  flexShrink: 0,
+                  marginTop: 4,
+                }}
+              />
+
+              {/* Content */}
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Text
+                  sx={{
+                    fontSize: '11px',
+                    fontFamily: 'mono',
+                    color: item.status === 'done' ? 'fg.muted' : 'fg.default',
+                    textDecoration: item.status === 'done' ? 'line-through' : 'none',
+                    wordBreak: 'break-all',
+                    display: 'block',
+                  }}
+                >
+                  {item.description}
+                </Text>
+                {item.status === 'running' && item.assignedTileName && (
+                  <Text sx={{ fontSize: '9px', color: 'attention.fg', mt: '2px', display: 'block' }}>
+                    on: {item.assignedTileName}
+                  </Text>
+                )}
+                {item.status === 'failed' && (
+                  <Text sx={{ fontSize: '9px', color: 'danger.fg', mt: '2px', display: 'block' }}>
+                    Failed
+                  </Text>
+                )}
+              </Box>
+
+              {/* Actions */}
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '2px', flexShrink: 0 }}>
+                {item.status === 'pending' && (
+                  <>
+                    <ActionButton
+                      title="Move up"
+                      disabled={idx === 0}
+                      onClick={() => onReorderItem(item.id, 'up')}
+                    >
+                      <ChevronUpIcon size={10} />
+                    </ActionButton>
+                    <ActionButton
+                      title="Move down"
+                      disabled={idx === items.length - 1}
+                      onClick={() => onReorderItem(item.id, 'down')}
+                    >
+                      <ChevronDownIcon size={10} />
+                    </ActionButton>
+                  </>
+                )}
+                {item.status === 'failed' && (
+                  <ActionButton title="Retry" onClick={() => onRetryItem(item.id)}>
+                    <SyncIcon size={10} />
+                  </ActionButton>
+                )}
+                {item.status !== 'running' && (
+                  <ActionButton title="Remove" onClick={() => onRemoveItem(item.id)} danger>
+                    <XIcon size={10} />
+                  </ActionButton>
+                )}
+              </Box>
+            </Box>
+          ))
+        )}
+      </Box>
+
+      {/* Footer */}
+      {items.length > 0 && (
+        <Box
+          sx={{
+            px: 2,
+            py: '6px',
+            borderTop: '1px solid',
+            borderColor: 'border.muted',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexShrink: 0,
+          }}
+        >
+          <Text sx={{ fontSize: '10px', color: 'fg.muted', fontFamily: 'mono' }}>
+            {pendingCount}P {runningCount}R {doneCount}D {failedCount}F
+          </Text>
+          {doneCount > 0 && (
+            <button
+              type="button"
+              onClick={onClearCompleted}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                padding: '2px 6px',
+                borderRadius: 4,
+                border: '1px solid var(--borderColor-muted, #21262d)',
+                background: 'transparent',
+                color: 'var(--fgColor-muted, #8b949e)',
+                fontSize: 10,
+                cursor: 'pointer',
+              }}
+            >
+              <TrashIcon size={10} />
+              Clear done
+            </button>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/** Small action button for todo item actions */
+function ActionButton({
+  children,
+  title,
+  onClick,
+  disabled,
+  danger,
+}: {
+  children: React.ReactNode;
+  title: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      disabled={disabled}
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 18,
+        height: 18,
+        borderRadius: 3,
+        border: 'none',
+        background: 'transparent',
+        color: danger ? 'var(--fgColor-danger, #f85149)' : 'var(--fgColor-muted, #8b949e)',
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.3 : 1,
+        padding: 0,
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/web/src/hooks/useTodoDispatcher.ts
+++ b/web/src/hooks/useTodoDispatcher.ts
@@ -1,0 +1,262 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { TodoItem } from '../types';
+import { api } from '../lib/api';
+
+/** localStorage key for todo items */
+const TODO_ITEMS_KEY = 'copilot-remote-todo-items';
+
+/** localStorage key for todo mode toggle */
+const TODO_MODE_KEY = 'copilot-remote-todo-mode';
+
+/** Debounce interval (ms) for syncing state to the server */
+const TODO_SERVER_SYNC_DEBOUNCE_MS = 2000;
+
+/** Generate a unique todo item ID */
+function generateTodoId(): string {
+  return `todo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Load items from localStorage */
+function loadItems(): TodoItem[] {
+  try {
+    const raw = localStorage.getItem(TODO_ITEMS_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch { return []; }
+}
+
+/** Load todoMode from localStorage */
+function loadTodoMode(): boolean {
+  return localStorage.getItem(TODO_MODE_KEY) === 'true';
+}
+
+interface TermInstance {
+  ws: WebSocket;
+  connected: boolean;
+}
+
+interface TermTab {
+  id: string;
+  name: string;
+}
+
+export interface TodoDispatcher {
+  items: TodoItem[];
+  todoMode: boolean;
+  addItem: (description: string) => void;
+  removeItem: (id: string) => void;
+  retryItem: (id: string) => void;
+  toggleTodoMode: () => void;
+  clearCompleted: () => void;
+  reorderItem: (id: string, direction: 'up' | 'down') => void;
+  onTilePromptReturned: (tileId: string) => void;
+  onTileDisconnected: (tileId: string) => void;
+}
+
+export function useTodoDispatcher(
+  getTermInstances: () => Map<string, TermInstance>,
+  tabs: TermTab[],
+): TodoDispatcher {
+  const [items, setItems] = useState<TodoItem[]>(loadItems);
+  const [todoMode, setTodoMode] = useState<boolean>(loadTodoMode);
+
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+
+  const todoModeRef = useRef(todoMode);
+  todoModeRef.current = todoMode;
+
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
+
+  const syncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Persist to localStorage on every change
+  useEffect(() => {
+    localStorage.setItem(TODO_ITEMS_KEY, JSON.stringify(items));
+    localStorage.setItem(TODO_MODE_KEY, String(todoMode));
+
+    // Debounced server sync
+    if (syncTimerRef.current) clearTimeout(syncTimerRef.current);
+    syncTimerRef.current = setTimeout(() => {
+      api.saveTodos(items, todoMode).catch(() => {
+        /* server sync is best-effort */
+      });
+    }, TODO_SERVER_SYNC_DEBOUNCE_MS);
+  }, [items, todoMode]);
+
+  // Load from server on mount (merge with localStorage)
+  useEffect(() => {
+    api.getTodos().then(({ items: serverItems, todoMode: serverMode }) => {
+      if (serverItems && serverItems.length > 0) {
+        const localItems = loadItems();
+        // If localStorage is empty, use server data
+        if (localItems.length === 0) {
+          setItems(serverItems);
+          setTodoMode(serverMode);
+        }
+      }
+    }).catch(() => { /* server may be unreachable */ });
+  }, []);
+
+  /** Dispatch a todo item to a specific tile */
+  const dispatchToTile = useCallback((item: TodoItem, tileId: string) => {
+    const termInstances = getTermInstances();
+    const inst = termInstances.get(tileId);
+    if (!inst || !inst.connected || inst.ws.readyState !== WebSocket.OPEN) return;
+
+    const tab = tabsRef.current.find(t => t.id === tileId);
+
+    // Send the command to the terminal
+    inst.ws.send(item.description + '\r');
+
+    // Tell the server to start watching for prompt return
+    inst.ws.send(JSON.stringify({ type: 'watch-prompt' }));
+
+    // Update item state
+    setItems(prev => prev.map(i =>
+      i.id === item.id
+        ? {
+          ...i,
+          status: 'running' as const,
+          assignedTileId: tileId,
+          assignedTileName: tab?.name || tileId,
+          startedAt: new Date().toISOString(),
+        }
+        : i
+    ));
+  }, [getTermInstances]);
+
+  /** Find first idle tile (connected, no running item assigned) */
+  const findIdleTile = useCallback((): string | null => {
+    const termInstances = getTermInstances();
+    const currentItems = itemsRef.current;
+
+    for (const tab of tabsRef.current) {
+      const inst = termInstances.get(tab.id);
+      if (!inst || !inst.connected || inst.ws.readyState !== WebSocket.OPEN) continue;
+
+      const hasRunning = currentItems.some(
+        i => i.status === 'running' && i.assignedTileId === tab.id
+      );
+      if (!hasRunning) return tab.id;
+    }
+    return null;
+  }, [getTermInstances]);
+
+  /** Try to dispatch the next pending item to any idle tile */
+  const tryDispatchNext = useCallback(() => {
+    if (!todoModeRef.current) return;
+
+    const nextPending = itemsRef.current.find(i => i.status === 'pending');
+    if (!nextPending) return;
+
+    const idleTile = findIdleTile();
+    if (!idleTile) return;
+
+    dispatchToTile(nextPending, idleTile);
+  }, [findIdleTile, dispatchToTile]);
+
+  const addItem = useCallback((description: string) => {
+    const trimmed = description.trim();
+    if (!trimmed) return;
+
+    const newItem: TodoItem = {
+      id: generateTodoId(),
+      description: trimmed,
+      status: 'pending',
+      assignedTileId: null,
+      assignedTileName: null,
+      createdAt: new Date().toISOString(),
+      startedAt: null,
+      completedAt: null,
+    };
+
+    setItems(prev => {
+      const updated = [...prev, newItem];
+      // Schedule dispatch after state updates
+      setTimeout(() => tryDispatchNext(), 0);
+      return updated;
+    });
+  }, [tryDispatchNext]);
+
+  const removeItem = useCallback((id: string) => {
+    setItems(prev => prev.filter(i => i.id !== id));
+  }, []);
+
+  const retryItem = useCallback((id: string) => {
+    setItems(prev => prev.map(i =>
+      i.id === id
+        ? { ...i, status: 'pending' as const, assignedTileId: null, assignedTileName: null, startedAt: null, completedAt: null }
+        : i
+    ));
+    setTimeout(() => tryDispatchNext(), 0);
+  }, [tryDispatchNext]);
+
+  const toggleTodoMode = useCallback(() => {
+    setTodoMode(prev => {
+      const next = !prev;
+      if (next) {
+        // Turning ON — try dispatching immediately
+        setTimeout(() => tryDispatchNext(), 0);
+      }
+      return next;
+    });
+  }, [tryDispatchNext]);
+
+  const clearCompleted = useCallback(() => {
+    setItems(prev => prev.filter(i => i.status !== 'done'));
+  }, []);
+
+  const reorderItem = useCallback((id: string, direction: 'up' | 'down') => {
+    setItems(prev => {
+      const idx = prev.findIndex(i => i.id === id);
+      if (idx < 0) return prev;
+
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      if (swapIdx < 0 || swapIdx >= prev.length) return prev;
+
+      const next = [...prev];
+      [next[idx], next[swapIdx]] = [next[swapIdx], next[idx]];
+      return next;
+    });
+  }, []);
+
+  const onTilePromptReturned = useCallback((tileId: string) => {
+    // Find the running item assigned to this tile and mark done
+    setItems(prev => {
+      const updated = prev.map(i =>
+        i.status === 'running' && i.assignedTileId === tileId
+          ? { ...i, status: 'done' as const, completedAt: new Date().toISOString() }
+          : i
+      );
+
+      // After marking done, try dispatching next pending item
+      if (todoModeRef.current) {
+        setTimeout(() => tryDispatchNext(), 0);
+      }
+
+      return updated;
+    });
+  }, [tryDispatchNext]);
+
+  const onTileDisconnected = useCallback((tileId: string) => {
+    setItems(prev => prev.map(i =>
+      i.status === 'running' && i.assignedTileId === tileId
+        ? { ...i, status: 'failed' as const, completedAt: new Date().toISOString() }
+        : i
+    ));
+  }, []);
+
+  return {
+    items,
+    todoMode,
+    addItem,
+    removeItem,
+    retryItem,
+    toggleTodoMode,
+    clearCompleted,
+    reorderItem,
+    onTilePromptReturned,
+    onTileDisconnected,
+  };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Session, ChatMessage } from '../types';
+import type { Session, ChatMessage, TodoItem } from '../types';
 
 const getBaseUrl = () => {
   const stored = localStorage.getItem('copilot-remote-server');
@@ -51,4 +51,10 @@ export const api = {
 
   removeTag: (id: string, tag: string) =>
     request<{ tags: string[] }>(`/api/sessions/${id}/tags/${encodeURIComponent(tag)}`, { method: 'DELETE' }),
+
+  getTodos: () =>
+    request<{ items: TodoItem[]; todoMode: boolean }>('/api/todos'),
+
+  saveTodos: (items: TodoItem[], todoMode: boolean) =>
+    request<{ ok: boolean }>('/api/todos', { method: 'PUT', body: JSON.stringify({ items, todoMode }) }),
 };

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -18,6 +18,19 @@ export interface ChatMessage {
   timestamp: string;
 }
 
+export type TodoStatus = 'pending' | 'running' | 'done' | 'failed';
+
+export interface TodoItem {
+  id: string;
+  description: string;
+  status: TodoStatus;
+  assignedTileId: string | null;
+  assignedTileName: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
 export interface WsMessage {
   type: 'output' | 'status' | 'sessions' | 'message' | 'error' | 'stream' | 'tool' | 'turn_complete';
   sessionId?: string;


### PR DESCRIPTION
## Summary

- Adds a side panel with a FIFO task queue that tiled terminal sessions consume autonomously
- When "Todo Mode" is ON, idle tiles automatically pick up the next pending item from the queue
- Shell prompt detection (debounced pattern matching on PTY output) determines when a command finishes
- Items persist via localStorage (primary) with debounced server sync to `~/.copilot-remote/todo.json`

## Architecture

### New Files (4)
| File | Purpose |
|------|---------|
| `server/src/prompt-detector.ts` | Debounced shell prompt detection on PTY output stream |
| `server/src/todo-store.ts` | Server-side JSON persistence following `session-meta.ts` pattern |
| `web/src/hooks/useTodoDispatcher.ts` | React hook: state, localStorage persistence, dispatch logic |
| `web/src/components/TodoPanel.tsx` | Side panel UI: input, item list, status dots, reorder, retry |

### Modified Files (5)
| File | Changes |
|------|---------|
| `server/src/terminal-manager.ts` | Feed PTY data to prompt detector, expose watch/unwatch methods |
| `server/src/index.ts` | Wire `prompt` event on terminal WS, add `GET/PUT /api/todos`, fix CORS for PUT |
| `web/src/types.ts` | Add `TodoItem` and `TodoStatus` types |
| `web/src/lib/api.ts` | Add `getTodos()` and `saveTodos()` API methods |
| `web/src/components/TerminalView.tsx` | Wire hook, add panel toggle button, handle prompt/disconnect events, keyboard shortcut |

### Key Design Decisions
- **Prompt detection**: Debounced (300ms) ANSI-stripped pattern matching against common shell prompt endings (`$`, `#`, `%`, `>`, `❯`, `➜`, `λ`)
- **Dispatch flow**: Client sends command + `watch-prompt` message → server watches PTY → emits `prompt` event → client marks item done and dispatches next
- **Persistence**: localStorage is primary (instant), server sync is debounced best-effort (for cross-tab/restart)
- **No magic numbers**: All timeouts, sizes, and keys are named constants

## Keyboard Shortcuts
- `Cmd+Shift+D` / `Ctrl+Shift+D` — Toggle todo panel

## Test plan
- [ ] Open terminal view, click todo panel toggle → panel appears on the right
- [ ] Add items: `echo hello`, `sleep 2 && echo done`, `ls -la`
- [ ] Open 2+ tiles (check tabs, toggle tile mode)
- [ ] Toggle Todo Mode ON → items dispatch to idle tiles
- [ ] Items show running (yellow dot), then done (green dot) on prompt return
- [ ] Toggle Todo Mode OFF → no more auto-dispatch
- [ ] Kill a tile while it has a running item → item marks failed (red dot)
- [ ] Click retry on failed item → returns to pending and re-dispatches
- [ ] Refresh page → items persist from localStorage
- [ ] Add item with no tiles open → stays pending until one connects

Closes #114