### PR TITLE
🐛 Fix Express 5 wildcard route syntax for SPA fallback

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -426,8 +426,8 @@ app.get('/swarm', (_req, res) => {
   res.sendFile(path.join(DIST_DIR, 'swarm.html'));
 });
 
-// SPA fallback (must be last static route)
-app.get('*', (req, res, next) => {
+// SPA fallback (must be last static route — Express 5 uses {*path} syntax)
+app.get('{*path}', (req, res, next) => {
   // Skip API and WebSocket paths
   if (req.path.startsWith('/api') || req.path.startsWith('/ws') || req.path.startsWith('/swarm/api')) {
     next();


### PR DESCRIPTION
## Summary

- Express 5 uses `path-to-regexp` v8 which no longer supports bare `*` wildcard
- Changed SPA fallback route from `app.get('*', ...)` to `app.get('{*path}', ...)`
- Server was crashing on startup with `PathError: Missing parameter name at index 1`

## Test plan

- [ ] Server starts without `PathError`
- [ ] SPA fallback serves `index.html` for non-API routes