### PR TITLE
🐛 Fix mouse scroll in tmux sessions via web terminal

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -270,6 +270,11 @@ export function TerminalView({ onBack }: Props) {
       if (ws.readyState === WebSocket.OPEN) ws.send(data);
     });
 
+    // Forward mouse events (scroll, click) so tmux mouse mode works
+    term.onBinary((data) => {
+      if (ws.readyState === WebSocket.OPEN) ws.send(data);
+    });
+
     term.onResize(({ cols, rows }) => {
       if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'resize', cols, rows }));
     });


### PR DESCRIPTION
## Problem
Mouse scroll in the web terminal triggers shell history navigation instead of scrolling the tmux scrollback buffer, even with `set -g mouse on` in tmux config.

## Root Cause
xterm.js emits mouse events (scroll, click) via `term.onBinary()`, not `term.onData()`. The frontend only had an `onData` handler, so mouse escape sequences were never forwarded to the PTY. tmux never received mouse input.

## Fix
Added `term.onBinary()` handler alongside `term.onData()` to forward binary data (mouse escape sequences) over the websocket to the server PTY.

This enables:
- ✅ Mouse scroll → tmux scrollback (instead of shell history)
- ✅ Click to select tmux pane
- ✅ Drag to resize tmux panes

No server-side changes needed — the server already writes raw data to the PTY.