### PR TITLE
🌱 Sync workflows from kubestellar/infra

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,4 +23,4 @@ jobs:
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:
-      token: ${{ secrets.ORG_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -1,0 +1,31 @@
+name: Copilot PR Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to process
+        required: true
+        type: string
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review]
+
+# Restrict to same-repo PRs only (defense against fork-based attacks via pull_request_target)
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  statuses: write
+
+concurrency:
+  group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  copilot-automation:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
+    with:
+      pr_number: ${{ github.event.inputs.pr_number || '' }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -1,0 +1,14 @@
+name: Copilot DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  copilot-dco:
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -1,0 +1,14 @@
+name: Feedback Wanted
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  feedback:
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,17 @@
+name: Greetings
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  greet:
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    secrets: inherit

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -1,0 +1,15 @@
+name: Label Helper
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label-helper:
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -1,0 +1,14 @@
+name: PR Verifier
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  checks: write
+  pull-requests: read
+
+jobs:
+  verify:
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-verify-title.yml
+++ b/.github/workflows/pr-verify-title.yml
@@ -1,0 +1,14 @@
+name: "PR Title Verifier"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  verify:
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verify-title.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,19 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+  id-token: write
+
+jobs:
+  analysis:
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,14 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
+    secrets: inherit


### PR DESCRIPTION
Replaces #121 (closed due to shallow clone issue).

Syncs caller workflows from `kubestellar/infra` with security hardening:

**Standard Workflows:**
- `feedback.yml` - Collect feedback on merged PRs
- `greetings.yml` - Welcome new contributors
- `label-helper.yml` - Manage labels via comments
- `pr-verifier.yml` - Verify PR contents
- `pr-verify-title.yml` - Verify PR title format
- `scorecard.yml` - OpenSSF security scorecard
- `stale.yml` - Mark stale issues/PRs

**Agentic Workflows (Copilot Integration):**
- `ai-fix.yml` - Switched from `ORG_TOKEN` to `GITHUB_TOKEN`
- `copilot-automation.yml` - Automate Copilot PR processing (with fork protection on `pull_request_target`)
- `copilot-dco.yml` - Override DCO for Copilot PRs (with explicit permissions)

**Security hardening vs original #121:**
- Added `if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository` to copilot-automation to block fork-based attacks
- Added explicit `permissions` block to copilot-dco to avoid broad defaults