### PR TITLE
✨ Default to Terminals tab with todo panel open

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,7 @@ import type { WsMessage, ChatMessage } from './types';
 export default function App() {
   const [activeTab, setActiveTab] = useState<'sessions' | 'terminal'>(() => {
     const saved = localStorage.getItem('copilot-remote-active-tab');
-    return saved === 'terminal' ? 'terminal' : 'sessions';
+    return saved === 'sessions' ? 'sessions' : 'terminal';
   });
   const [activeSessionId, setActiveSessionId] = useState<string | null>(
     () => localStorage.getItem('copilot-remote-active-session')
@@ -209,7 +209,7 @@ export default function App() {
             onClick={() => setActiveTab('terminal')}
             icon={TerminalIcon}
           >
-            Bidirectional
+            Terminals
           </UnderlineNav.Item>
         </UnderlineNav>
       </Box>

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -160,7 +160,7 @@ export function TerminalView({ onBack }: Props) {
   const [focusedTileId, setFocusedTileId] = useState<string | null>(null);
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
-  const [showTodoPanel, setShowTodoPanel] = useState(() => localStorage.getItem(TODO_PANEL_KEY) === 'true');
+  const [showTodoPanel, setShowTodoPanel] = useState(() => localStorage.getItem(TODO_PANEL_KEY) !== 'false');
   const singleContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const tileContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const intentRef = useRef<Map<string, string>>(new Map());


### PR DESCRIPTION
## Summary
- App now opens on the Terminals tab by default instead of Sessions
- Todo panel is open by default on first visit (users can still close it and it remembers)
- Renamed "Bidirectional" tab label to "Terminals" for clarity

## Test plan
- [ ] Fresh visit (clear localStorage) lands on Terminals tab with todo panel open
- [ ] Switching to Sessions tab and refreshing remembers Sessions
- [ ] Closing todo panel and refreshing remembers it closed