### PR TITLE
🌱 Add hover tooltips and update README for Terminals tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Tap **+ New**, enter a prompt like `"Fix the failing tests in src/"`, optionally
 
 ### 5. Use the Todo Queue
 
-Switch to the **Bidirectional** tab, open some terminals, and toggle **Todo Mode** on. Now you can:
+Switch to the **Terminals** tab (it opens by default), and toggle **Todo Mode** on. Now you can:
 
 1. **Add tasks** — Type commands in the input box at the bottom of the todo panel and hit Enter
 2. **Watch them run** — Tasks auto-dispatch to idle terminals and show "running in: tab-name" while they execute

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1139,7 +1139,7 @@ export function TerminalView({ onBack }: Props) {
           </button>
           <ActionMenu>
             <ActionMenu.Anchor>
-              <IconButton icon={LinkIcon} aria-label="Attach tmux session (⌘⇧L)" variant="invisible" size="small" sx={{ flexShrink: 0, color: 'accent.fg' }} onClick={fetchTmuxSessions} />
+              <IconButton icon={LinkIcon} aria-label="Attach tmux session (⌘⇧L)" title="Attach tmux session (⌘⇧L)" variant="invisible" size="small" sx={{ flexShrink: 0, color: 'accent.fg' }} onClick={fetchTmuxSessions} />
             </ActionMenu.Anchor>
             <ActionMenu.Overlay sx={{ bg: 'canvas.overlay', borderColor: 'border.default', boxShadow: 'shadow.large' }}>
               <ActionList sx={{ bg: 'canvas.overlay' }}>
@@ -1169,7 +1169,7 @@ export function TerminalView({ onBack }: Props) {
           </ActionMenu>
           <ActionMenu>
             <ActionMenu.Anchor>
-              <IconButton icon={PlusIcon} aria-label="New terminal (⌘⇧N)" variant="invisible" size="small" sx={{ flexShrink: 0, color: 'success.fg' }} />
+              <IconButton icon={PlusIcon} aria-label="New terminal (⌘⇧N)" title="New terminal (⌘⇧N)" variant="invisible" size="small" sx={{ flexShrink: 0, color: 'success.fg' }} />
             </ActionMenu.Anchor>
             <ActionMenu.Overlay sx={{ bg: 'canvas.overlay', borderColor: 'border.default', boxShadow: 'shadow.large' }}>
               <ActionList sx={{ bg: 'canvas.overlay' }}>


### PR DESCRIPTION
## Summary
- Added `title` attributes to Attach and New terminal IconButtons so hover text shows up
- Updated README to say "Terminals" tab instead of "Bidirectional"

## Test plan
- [ ] Hover over attach (link) icon — tooltip shows "Attach tmux session"
- [ ] Hover over new (plus) icon — tooltip shows "New terminal"
- [ ] README references "Terminals" tab correctly