### PR TITLE
🐛 Use native browser paste for terminal clipboard

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -227,20 +227,17 @@ export function TerminalView({ onBack }: Props) {
     term.element?.addEventListener('contextmenu', (e) => e.preventDefault());
 
     // Clipboard: Cmd/Ctrl+C (copy), Cmd/Ctrl+V (paste), Cmd/Ctrl+X (cut), Cmd/Ctrl+A (select all)
+    // Returning false tells xterm to skip processing (won't send control chars to PTY)
+    // but does NOT preventDefault, so the browser's native clipboard events still fire.
     term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
       if (e.type !== 'keydown') return true;
       const isMac = navigator.platform.startsWith('Mac');
       const mod = isMac ? e.metaKey : e.ctrlKey;
       if (!mod) return true;
 
-      // Paste: read system clipboard and send to terminal via WebSocket
-      if (e.key === 'v') {
-        navigator.clipboard.readText().then(text => {
-          if (text && ws.readyState === WebSocket.OPEN) ws.send(text);
-        }).catch(() => {});
-        return false;
-      }
-      // Copy / Cut: copy selected text to system clipboard
+      // Paste: let browser handle natively (fires paste event → xterm processes it)
+      if (e.key === 'v') return false;
+      // Copy / Cut: copy xterm selection to system clipboard
       if ((e.key === 'c' || e.key === 'x') && term.hasSelection()) {
         navigator.clipboard.writeText(term.getSelection()).catch(() => {});
         return false;


### PR DESCRIPTION
Simplifies Cmd/Ctrl+V paste by removing the explicit `navigator.clipboard.readText()` call and relying on the browser's native paste event instead.

**Why:** When `attachCustomKeyEventHandler` returns `false`, xterm.js skips processing but does NOT call `preventDefault()`. This allows the browser to fire its native `paste` event, which xterm.js handles through its built-in textarea paste handler.

**Benefits:**
- No clipboard API permission needed (works without granting clipboard-read access)
- Avoids potential double-paste (clipboard API + native paste both firing)
- Works consistently in both single terminal and tile modes
- Simpler, less code

Copy (Cmd+C), Cut (Cmd+X), and Select All (Cmd+A) are unchanged.