### PR TITLE
✨ OSC 52 clipboard support with copy toast

### DIFF
--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -49,6 +49,8 @@ class TerminalManager extends EventEmitter {
       try {
         execSync(`${TMUX_PATH} set-option -g window-size latest`, { stdio: 'ignore' });
         execSync(`${TMUX_PATH} set-option -g aggressive-resize on`, { stdio: 'ignore' });
+        execSync(`${TMUX_PATH} set-option -g set-clipboard on`, { stdio: 'ignore' });
+        execSync(`${TMUX_PATH} set-option -g allow-passthrough on`, { stdio: 'ignore' });
         execSync(`${TMUX_PATH} set-hook -g session-created 'set-option window-size latest'`, { stdio: 'ignore' });
         execSync(`${TMUX_PATH} set-hook -g client-attached 'set-option window-size latest'`, { stdio: 'ignore' });
       } catch {}
@@ -69,6 +71,7 @@ class TerminalManager extends EventEmitter {
       term = pty.spawn(TMUX_PATH, [
         'new-session', '-s', tmuxName, '-x', '80', '-y', '24',
         ';', 'set', 'mouse', 'on',
+        ';', 'set', 'set-clipboard', 'on',
         ';', 'set', 'window-size', 'latest',
         ';', 'set', 'aggressive-resize', 'on',
       ], {
@@ -141,10 +144,12 @@ class TerminalManager extends EventEmitter {
     try {
       execSync(`${TMUX_PATH} set-option -t "${tmuxSession}" window-size latest`, { stdio: 'ignore' });
       execSync(`${TMUX_PATH} set-option -t "${tmuxSession}" mouse on`, { stdio: 'ignore' });
+      execSync(`${TMUX_PATH} set-option -t "${tmuxSession}" set-clipboard on`, { stdio: 'ignore' });
     } catch {}
     const term = pty.spawn(TMUX_PATH, [
       'new-session', '-s', groupName, '-t', tmuxSession,
       ';', 'set', 'mouse', 'on',
+      ';', 'set', 'set-clipboard', 'on',
       ';', 'set', 'window-size', 'latest',
       ';', 'set', 'aggressive-resize', 'on',
     ], {

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -26,10 +26,37 @@ tileXtermStyles.textContent = `
     pointer-events: none; z-index: 10; text-shadow: 0 0 8px rgba(0,0,0,0.8);
     background: rgba(13, 17, 23, 0.7); padding: 8px 16px; border-radius: 6px;
   }
+  .copy-toast {
+    position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(20px);
+    background: rgba(30, 37, 46, 0.85); color: #8b949e; font-size: 11px;
+    padding: 4px 12px; border-radius: 4px; pointer-events: none; z-index: 9999;
+    opacity: 0; transition: opacity 0.2s, transform 0.2s;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+  .copy-toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
 `;
 if (!document.head.querySelector('[data-tile-xterm]')) {
   tileXtermStyles.setAttribute('data-tile-xterm', '');
   document.head.appendChild(tileXtermStyles);
+}
+
+/** Last text copied via OSC 52 — fallback for clipboard API failures */
+let _lastOsc52Text = '';
+
+/** Show a subtle toast when text is copied */
+function showCopyToast(text: string) {
+  let el = document.getElementById('copy-toast');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'copy-toast';
+    el.className = 'copy-toast';
+    document.body.appendChild(el);
+  }
+  const preview = text.length > 30 ? text.slice(0, 30) + '…' : text;
+  el.textContent = `Copied: ${preview.replace(/\n/g, '↵')}`;
+  el.classList.add('show');
+  clearTimeout((el as any)._timer);
+  (el as any)._timer = setTimeout(() => el!.classList.remove('show'), 1500);
 }
 
 interface TermTab {
@@ -294,6 +321,21 @@ export function TerminalView({ onBack }: Props) {
           return;
         }
       } catch (_parseErr) { /* raw terminal data */ }
+      // Intercept OSC 52 clipboard sequences from tmux
+      if (typeof e.data === 'string') {
+        const osc52Re = /\x1b\]52;([^;]*);([^\x07\x1b]*?)(?:\x07|\x1b\\)/g;
+        let match;
+        while ((match = osc52Re.exec(e.data)) !== null) {
+          try {
+            const decoded = atob(match[2]);
+            if (decoded.trim()) {
+              _lastOsc52Text = decoded;
+              showCopyToast(decoded);
+              navigator.clipboard.writeText(decoded).catch(() => {});
+            }
+          } catch {}
+        }
+      }
       term.write(e.data);
     };
 


### PR DESCRIPTION
## Changes
- Configure tmux `set-clipboard on` and `allow-passthrough on` so tmux sends OSC 52 escape sequences when text is selected
- Parse OSC 52 sequences from WebSocket data on the client side
- Write decoded text to browser clipboard via `navigator.clipboard.writeText()`  
- Show subtle toast notification ('Copied: ...') at bottom center for 1.5s
- Store last copied text as fallback

## How it works
1. User double-clicks a word in tmux → tmux selects it (gold flash)
2. tmux sends OSC 52 escape sequence through the PTY
3. Client parses the base64-encoded text from the sequence
4. Text is written to browser clipboard + toast shown
5. User can Cmd+V to paste anywhere