### PR TITLE
🐛 Force terminal redraw after moving to tile containers

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -883,6 +883,14 @@ export function TerminalView({ onBack }: Props) {
           }
           inst.container = el;
           try { inst.fitAddon.fit(); inst.term.scrollToBottom(); } catch (_err) { /* fit may fail before terminal is fully mounted */ }
+          // Force full redraw — moving the canvas element between DOM containers loses rendered content
+          setTimeout(() => {
+            try {
+              inst.fitAddon.fit();
+              inst.term.refresh(0, inst.term.rows - 1);
+              inst.term.scrollToBottom();
+            } catch {}
+          }, 50);
         } else {
           createTermConnection(tab.id, el, tileFontSize);
         }
@@ -900,7 +908,7 @@ export function TerminalView({ onBack }: Props) {
         if (cancelled) return;
         for (const tab of checked) {
           const inst = termInstances.get(tab.id);
-          if (inst) try { inst.fitAddon.fit(); inst.term.scrollToBottom(); } catch {}
+          if (inst) try { inst.fitAddon.fit(); inst.term.refresh(0, inst.term.rows - 1); inst.term.scrollToBottom(); } catch {}
         }
       });
     };


### PR DESCRIPTION
When xterm.js elements are moved between DOM containers via appendChild, the canvas renderer loses its visual content. Adds `term.refresh(0, rows-1)` after tile mounting to force a full redraw of the terminal buffer.

Fixes: tiles showing blank/empty areas when entering tile mode.