### PR TITLE
✨ CSS scale tiles to preserve terminal content without resize

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -880,9 +880,10 @@ export function TerminalView({ onBack }: Props) {
     : checkedTabs.length <= 9 ? 3
     : 4;
 
-  // Fit terminals to their containers using fitAddon (tile mode or single mode).
-  // With unified containers (no DOM reparenting), fitAddon.fit() is safe —
-  // terminals reflow to the tile cell size at normal font, no CSS scaling needed.
+  // Tile mode: CSS scale to preserve terminal content without any resize.
+  // fitAddon.fit() or PTY resize would cause alternate-screen apps (Claude Code)
+  // to clear and redraw at idle state, losing visible content. CSS transform:scale()
+  // shrinks the full-viewport terminal visually into the tile cell.
   useEffect(() => {
     if (!tileMode || !fontReady) {
       if (!tileMode) {
@@ -917,15 +918,15 @@ export function TerminalView({ onBack }: Props) {
         if (active && checked.some(t => t.id === active)) return active;
         return checked[0].id;
       });
-      // Ensure activeTabId is among checked tiles (so tab bar highlights correctly)
       const currentActive = activeTabIdRef.current;
       if (!currentActive || !checked.some(t => t.id === currentActive)) {
         setActiveTabId(checked[0].id);
       }
     }
 
-    const fitTiles = () => {
+    const scaleTiles = () => {
       if (cancelled) return;
+      suppressPtyResize = true;
       const checked = tabsRef.current.filter(t => t.checked);
 
       for (const tab of checked) {
@@ -935,19 +936,27 @@ export function TerminalView({ onBack }: Props) {
         if (!inst?.term.element) continue;
 
         const termEl = inst.term.element;
-        // Clear any leftover inline styles from previous approaches
-        termEl.style.transform = '';
-        termEl.style.transformOrigin = '';
-        termEl.style.width = '';
-        termEl.style.height = '';
+        // Get the terminal's natural full-viewport size.
+        // Because inactive single-mode tabs use visibility:hidden (not display:none),
+        // all terminals maintain their full-viewport layout dimensions.
+        const screen = termEl.querySelector('.xterm-screen') as HTMLElement | null;
+        const naturalW = screen?.offsetWidth || termEl.offsetWidth;
+        const naturalH = screen?.offsetHeight || termEl.offsetHeight;
 
-        // fitAddon.fit() resizes cols/rows to match the tile cell at current font.
-        // PTY resize IS sent so the remote app redraws at the correct width.
-        try { inst.fitAddon.fit(); } catch {}
-        inst.term.refresh(0, inst.term.rows - 1);
+        // Freeze element at natural size so grid doesn't auto-shrink it
+        termEl.style.width = naturalW + 'px';
+        termEl.style.height = naturalH + 'px';
+        termEl.style.transformOrigin = 'top left';
+        termEl.style.overflow = 'hidden';
 
-        // Wheel throttle for macOS trackpad — only throttle timing,
-        // don't block scroll from reaching xterm.js
+        const containerW = container.clientWidth;
+        const containerH = container.clientHeight;
+        if (containerW > 0 && containerH > 0 && naturalW > 0 && naturalH > 0) {
+          const scale = Math.min(containerW / naturalW, containerH / naturalH, 1);
+          termEl.style.transform = `scale(${scale})`;
+        }
+
+        // Wheel throttle for macOS trackpad
         let lastWheel = 0;
         const wheelHandler = (e: WheelEvent) => {
           const now = performance.now();
@@ -957,17 +966,17 @@ export function TerminalView({ onBack }: Props) {
             return;
           }
           lastWheel = now;
-          // Let xterm.js handle the event naturally
         };
         container.addEventListener('wheel', wheelHandler, { capture: true, passive: false });
         wheelHandlers.push({ el: container, handler: wheelHandler });
       }
+      suppressPtyResize = false;
     };
 
     // Apply after layout settles (two rAFs for grid to be fully rendered)
     requestAnimationFrame(() => {
       if (!cancelled) requestAnimationFrame(() => {
-        if (!cancelled) fitTiles();
+        if (!cancelled) scaleTiles();
       });
     });
 


### PR DESCRIPTION
## Problem

`fitAddon.fit()` + PTY resize causes Claude Code (alternate screen buffer) to redraw to idle state, making tiles appear blank. This was the persistent bug across PRs #142-#148.

## Root cause

Any terminal resize (local or remote) clears the alternate screen buffer. Claude Code redraws its TUI at the new size, which shows the current idle state — not the previous command output. The only way to preserve visible content is to avoid resizing entirely.

## Solution

CSS `transform:scale()` shrinks the full-viewport terminal visually into the tile cell:

1. Each `.xterm` element is frozen at its natural full-viewport size via inline `width`/`height`
2. `transform: scale(tileW/naturalW, tileH/naturalH)` applied with `transformOrigin: top left`
3. `suppressPtyResize = true` prevents remote app from receiving resize signal
4. Content is 100% preserved — what you saw in single mode is what you see in tile mode

Previous CSS scale attempts failed because inactive tabs used `display:none` (giving 0×0 dimensions). Now with `visibility:hidden`, all tabs maintain full-viewport layout for accurate size capture.

## Pixel analysis test results

Strong test: **top half** of each tile must have ≥5% bright pixels (catches 'content only at bottom prompt' false positives):

```
SINGLE: ✅ full=24.9% top_half=31.6%
2-TILE: ✅ left=11.6%/19.8%  right=42.0%/46.1%
4-TILE: ✅ TL=20.2%/33.7%  TR=45.9%/52.3%  BL=16.1%/21.8%  BR=45.6%/49.0%
```

## Visual verification

All tile configurations verified via CDP screenshots — content preserved in every tile, exit to single mode restores full viewport.