### PR TITLE
🐛 Fix scroll: synthetic re-dispatch with 200ms throttle

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -871,15 +871,19 @@ export function TerminalView({ onBack }: Props) {
     return () => window.removeEventListener('resize', handleResize);
   }, [tileMode]);
 
-  // Prevent macOS trackpad momentum "rocket scroll". Block ALL wheel events on
-  // terminals and manually call term.scrollLines() with a fixed small step.
-  // This completely eliminates momentum-based scroll flooding to tmux.
+  // Prevent macOS trackpad momentum "rocket scroll" while preserving scroll
+  // functionality in tmux. We block the raw wheel event, throttle aggressively,
+  // then re-dispatch a minimal synthetic event so xterm.js sends mouse-wheel
+  // escape sequences to tmux naturally. scrollLines() alone doesn't work because
+  // tmux uses alternate screen where xterm.js has no scrollback buffer.
   useEffect(() => {
     let lastWheel = 0;
-    const THROTTLE_MS = 100;  // 10 scroll actions/sec max
-    const SCROLL_LINES = 3;   // lines per scroll tick
+    const THROTTLE_MS = 200;  // 5 scroll events/sec max — very aggressive anti-momentum
 
     const handler = (e: WheelEvent) => {
+      // Let our synthetic events pass through to xterm.js
+      if ((e as any).__smoothScroll) return;
+
       const target = e.target as HTMLElement;
       if (!target?.closest?.('.xterm')) return;
 
@@ -893,16 +897,20 @@ export function TerminalView({ onBack }: Props) {
       if (now - lastWheel < THROTTLE_MS) return;
       lastWheel = now;
 
-      // Negate: browser deltaY>0 means "scroll page down" but xterm scrollLines(+)
-      // also moves viewport down. macOS natural scrolling inverts the raw delta,
-      // so we negate to match OS expectations (swipe-up = see older content).
-      const direction = e.deltaY > 0 ? -SCROLL_LINES : SCROLL_LINES;
-      for (const [, inst] of termInstances) {
-        if (inst.container?.contains(target)) {
-          inst.term.scrollLines(direction);
-          break;
-        }
-      }
+      // Re-dispatch with minimal deltaY (just the direction sign × small value).
+      // xterm.js only checks the sign for mouse-wheel escape sequences to tmux,
+      // so the magnitude doesn't matter — what matters is the rate.
+      const synth = new WheelEvent('wheel', {
+        deltaX: 0,
+        deltaY: e.deltaY > 0 ? 3 : -3,
+        deltaMode: 0,
+        bubbles: true,
+        cancelable: true,
+        clientX: e.clientX,
+        clientY: e.clientY,
+      });
+      Object.defineProperty(synth, '__smoothScroll', { value: true });
+      target.dispatchEvent(synth);
     };
     document.addEventListener('wheel', handler, { capture: true, passive: false } as any);
     return () => {

--- a/web/src/test/terminal-scroll.test.ts
+++ b/web/src/test/terminal-scroll.test.ts
@@ -2,33 +2,25 @@
  * Tests for the terminal wheel-event scroll handler.
  *
  * The handler intercepts ALL wheel events on .xterm elements to prevent macOS
- * trackpad momentum "rocket scroll". Instead of re-dispatching, it calls
- * term.scrollLines() with a fixed small step count.
+ * trackpad momentum "rocket scroll". It throttles aggressively (200ms) then
+ * re-dispatches a minimal synthetic event (deltaY ±3) so xterm.js can send
+ * mouse-wheel escape sequences to tmux naturally.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Handler constants (must match TerminalView.tsx) ─────────────────────
-const THROTTLE_MS = 100;
-const SCROLL_LINES = 3;
-
-/**
- * Mock terminal instances map — mirrors the module-level termInstances in
- * TerminalView.tsx. The handler iterates this to find the terminal whose
- * container owns the event target.
- */
-const termInstances = new Map<string, {
-  term: { scrollLines: ReturnType<typeof vi.fn> };
-  container: HTMLDivElement | null;
-}>();
+const THROTTLE_MS = 200;
 
 /**
  * Standalone version of the scroll handler logic extracted from TerminalView.
- * Uses the local termInstances map above.
+ * Attaches to `document` in capture phase, just like the real code.
  */
 function installScrollHandler() {
   let lastWheel = 0;
 
   const handler = (e: WheelEvent) => {
+    if ((e as any).__smoothScroll) return;
+
     const target = e.target as HTMLElement;
     if (!target?.closest?.('.xterm')) return;
 
@@ -39,13 +31,17 @@ function installScrollHandler() {
     if (now - lastWheel < THROTTLE_MS) return;
     lastWheel = now;
 
-    const direction = e.deltaY > 0 ? -SCROLL_LINES : SCROLL_LINES;
-    for (const [, inst] of termInstances) {
-      if (inst.container?.contains(target)) {
-        inst.term.scrollLines(direction);
-        break;
-      }
-    }
+    const synth = new WheelEvent('wheel', {
+      deltaX: 0,
+      deltaY: e.deltaY > 0 ? 3 : -3,
+      deltaMode: 0,
+      bubbles: true,
+      cancelable: true,
+      clientX: e.clientX,
+      clientY: e.clientY,
+    });
+    Object.defineProperty(synth, '__smoothScroll', { value: true });
+    target.dispatchEvent(synth);
   };
 
   document.addEventListener('wheel', handler, { capture: true });
@@ -53,16 +49,14 @@ function installScrollHandler() {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────
-function createXtermElement(): { container: HTMLDivElement; inner: HTMLDivElement } {
-  const container = document.createElement('div');
+function createXtermElement(): HTMLDivElement {
   const xterm = document.createElement('div');
   xterm.classList.add('xterm');
   const inner = document.createElement('div');
   inner.classList.add('xterm-screen');
   xterm.appendChild(inner);
-  container.appendChild(xterm);
-  document.body.appendChild(container);
-  return { container, inner };
+  document.body.appendChild(xterm);
+  return inner;
 }
 
 function fireWheel(target: HTMLElement, deltaY: number) {
@@ -78,52 +72,67 @@ function fireWheel(target: HTMLElement, deltaY: number) {
 // ── Tests ───────────────────────────────────────────────────────────────
 describe('Terminal scroll handler', () => {
   let cleanup: () => void;
-  let container: HTMLDivElement;
   let target: HTMLDivElement;
-  let mockTerm: { scrollLines: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
-    const el = createXtermElement();
-    container = el.container;
-    target = el.inner;
-    mockTerm = { scrollLines: vi.fn() };
-    termInstances.set('test-tab', { term: mockTerm, container });
+    target = createXtermElement();
     cleanup = installScrollHandler();
   });
 
   afterEach(() => {
     cleanup();
-    termInstances.clear();
-    container.remove();
+    target.parentElement?.remove();
   });
 
-  it('should call scrollLines with negative direction for scroll down (natural scrolling)', () => {
+  it('should re-dispatch a synthetic event with __smoothScroll flag', () => {
+    const received: WheelEvent[] = [];
+    target.addEventListener('wheel', (e) => received.push(e));
+
     fireWheel(target, 100);
-    expect(mockTerm.scrollLines).toHaveBeenCalledWith(-SCROLL_LINES);
+
+    expect(received.length).toBe(1);
+    expect((received[0] as any).__smoothScroll).toBe(true);
   });
 
-  it('should call scrollLines with positive direction for scroll up (natural scrolling)', () => {
-    fireWheel(target, -100);
-    expect(mockTerm.scrollLines).toHaveBeenCalledWith(SCROLL_LINES);
+  it('should normalize deltaY to ±3 regardless of input magnitude', () => {
+    const received: WheelEvent[] = [];
+    target.addEventListener('wheel', (e) => received.push(e));
+
+    fireWheel(target, 5000); // extreme momentum value
+    expect(received[0].deltaY).toBe(3);
   });
 
-  it('should use fixed step size regardless of deltaY magnitude', () => {
-    fireWheel(target, 5000); // extreme momentum
-    expect(mockTerm.scrollLines).toHaveBeenCalledWith(-SCROLL_LINES);
+  it('should preserve scroll direction: positive deltaY stays positive', () => {
+    const received: WheelEvent[] = [];
+    target.addEventListener('wheel', (e) => received.push(e));
+
+    fireWheel(target, 100);
+    expect(received[0].deltaY).toBe(3); // positive preserved
   });
 
-  it('should throttle rapid scroll events', async () => {
+  it('should preserve scroll direction: negative deltaY stays negative', () => {
+    const received: WheelEvent[] = [];
+    target.addEventListener('wheel', (e) => received.push(e));
+
+    fireWheel(target, -300);
+    expect(received[0].deltaY).toBe(-3); // negative preserved
+  });
+
+  it('should throttle at 200ms — blocks rapid momentum events', async () => {
+    const received: WheelEvent[] = [];
+    target.addEventListener('wheel', (e) => received.push(e));
+
     fireWheel(target, 50);
     fireWheel(target, 50);
     fireWheel(target, 50);
 
     // Only the first should pass throttle
-    expect(mockTerm.scrollLines).toHaveBeenCalledTimes(1);
+    expect(received.length).toBe(1);
 
     // Wait past throttle window then fire again
     await new Promise((r) => setTimeout(r, THROTTLE_MS + 10));
     fireWheel(target, 50);
-    expect(mockTerm.scrollLines).toHaveBeenCalledTimes(2);
+    expect(received.length).toBe(2);
   });
 
   it('should not intercept wheel events outside .xterm', () => {
@@ -141,26 +150,32 @@ describe('Terminal scroll handler', () => {
     outside.remove();
   });
 
-  it('should block original event (preventDefault + stopImmediatePropagation)', () => {
+  it('should let __smoothScroll events pass through untouched', () => {
+    const received: WheelEvent[] = [];
+    target.parentElement!.addEventListener('wheel', (e) => received.push(e));
+
+    const synth = new WheelEvent('wheel', {
+      deltaY: 42,
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(synth, '__smoothScroll', { value: true });
+    target.dispatchEvent(synth);
+
+    expect(received.length).toBe(1);
+    expect(received[0].deltaY).toBe(42); // untouched
+  });
+
+  it('should block original event from reaching parent (stopImmediatePropagation)', () => {
     const parentReceived: WheelEvent[] = [];
-    container.addEventListener('wheel', (e) => parentReceived.push(e));
+    // Listen in bubble phase on parent
+    target.parentElement!.addEventListener('wheel', (e) => {
+      if (!(e as any).__smoothScroll) parentReceived.push(e);
+    });
 
     fireWheel(target, 100);
 
-    // Parent should NOT receive the event (stopImmediatePropagation in capture)
+    // Parent should only see the synthetic, not the original
     expect(parentReceived.length).toBe(0);
-  });
-
-  it('should match terminal by container.contains(target)', () => {
-    const mockTerm2 = { scrollLines: vi.fn() };
-    const el2 = createXtermElement();
-    termInstances.set('tab-2', { term: mockTerm2, container: el2.container });
-
-    // Scroll in terminal 2's element
-    fireWheel(el2.inner, 100);
-    expect(mockTerm2.scrollLines).toHaveBeenCalledWith(-SCROLL_LINES);
-    expect(mockTerm.scrollLines).not.toHaveBeenCalled();
-
-    el2.container.remove();
   });
 });


### PR DESCRIPTION
scrollLines() doesn't work with tmux (alternate screen has no xterm.js scrollback). Switch to synthetic WheelEvent re-dispatch with 200ms throttle (5/sec max), deltaY normalized to ±3, suppressScroll during font changes. 8 scroll tests.