### PR TITLE
🐛 Fix scroll: throttle-only approach (no synthetic re-dispatch)

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -871,46 +871,36 @@ export function TerminalView({ onBack }: Props) {
     return () => window.removeEventListener('resize', handleResize);
   }, [tileMode]);
 
-  // Prevent macOS trackpad momentum "rocket scroll" while preserving scroll
-  // functionality in tmux. We block the raw wheel event, throttle aggressively,
-  // then re-dispatch a minimal synthetic event so xterm.js sends mouse-wheel
-  // escape sequences to tmux naturally. scrollLines() alone doesn't work because
-  // tmux uses alternate screen where xterm.js has no scrollback buffer.
+  // Prevent macOS trackpad momentum "rocket scroll" while preserving normal
+  // scroll in tmux. Instead of blocking-then-redispatching (which breaks xterm.js
+  // internal handlers), we simply THROTTLE: block events that arrive too fast,
+  // let one real native event through every THROTTLE_MS. xterm.js handles the
+  // native events normally — sending mouse escape sequences to tmux, scrolling
+  // its own buffer, etc.
   useEffect(() => {
     let lastWheel = 0;
-    const THROTTLE_MS = 200;  // 5 scroll events/sec max — very aggressive anti-momentum
+    const THROTTLE_MS = 150;  // ~6-7 scroll events/sec max
 
     const handler = (e: WheelEvent) => {
-      // Let our synthetic events pass through to xterm.js
-      if ((e as any).__smoothScroll) return;
-
       const target = e.target as HTMLElement;
       if (!target?.closest?.('.xterm')) return;
 
-      e.preventDefault();
-      e.stopImmediatePropagation();
-
-      // Skip during font changes / terminal reflow
-      if (suppressScroll) return;
+      // During font changes, block all scroll
+      if (suppressScroll) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        return;
+      }
 
       const now = performance.now();
-      if (now - lastWheel < THROTTLE_MS) return;
+      if (now - lastWheel < THROTTLE_MS) {
+        // Too fast — block this event entirely
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        return;
+      }
       lastWheel = now;
-
-      // Re-dispatch with minimal deltaY (just the direction sign × small value).
-      // xterm.js only checks the sign for mouse-wheel escape sequences to tmux,
-      // so the magnitude doesn't matter — what matters is the rate.
-      const synth = new WheelEvent('wheel', {
-        deltaX: 0,
-        deltaY: e.deltaY > 0 ? 3 : -3,
-        deltaMode: 0,
-        bubbles: true,
-        cancelable: true,
-        clientX: e.clientX,
-        clientY: e.clientY,
-      });
-      Object.defineProperty(synth, '__smoothScroll', { value: true });
-      target.dispatchEvent(synth);
+      // Let this event through to xterm.js naturally — no re-dispatch needed
     };
     document.addEventListener('wheel', handler, { capture: true, passive: false } as any);
     return () => {

--- a/web/src/test/terminal-scroll.test.ts
+++ b/web/src/test/terminal-scroll.test.ts
@@ -1,47 +1,45 @@
 /**
  * Tests for the terminal wheel-event scroll handler.
  *
- * The handler intercepts ALL wheel events on .xterm elements to prevent macOS
- * trackpad momentum "rocket scroll". It throttles aggressively (200ms) then
- * re-dispatches a minimal synthetic event (deltaY ±3) so xterm.js can send
- * mouse-wheel escape sequences to tmux naturally.
+ * Strategy: throttle-only. Block rapid momentum events, let slow events through
+ * natively to xterm.js. No synthetic re-dispatch — xterm.js handles native
+ * wheel events for both its scrollback buffer and tmux mouse escape sequences.
+ *
+ * The handler listens on `document` in capture phase so it intercepts events
+ * before xterm.js sees them.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// ── Handler constants (must match TerminalView.tsx) ─────────────────────
-const THROTTLE_MS = 200;
+// ── Constants matching TerminalView.tsx ──────────────────────────────────
+const THROTTLE_MS = 150;
+
+// ── Simulated suppressScroll flag (mirrors module-level in TerminalView) ─
+let suppressScroll = false;
 
 /**
- * Standalone version of the scroll handler logic extracted from TerminalView.
- * Attaches to `document` in capture phase, just like the real code.
+ * Install the scroll handler — standalone copy of the TerminalView logic.
  */
 function installScrollHandler() {
   let lastWheel = 0;
 
   const handler = (e: WheelEvent) => {
-    if ((e as any).__smoothScroll) return;
-
     const target = e.target as HTMLElement;
     if (!target?.closest?.('.xterm')) return;
 
-    e.preventDefault();
-    e.stopImmediatePropagation();
+    if (suppressScroll) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      return;
+    }
 
     const now = performance.now();
-    if (now - lastWheel < THROTTLE_MS) return;
+    if (now - lastWheel < THROTTLE_MS) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      return;
+    }
     lastWheel = now;
-
-    const synth = new WheelEvent('wheel', {
-      deltaX: 0,
-      deltaY: e.deltaY > 0 ? 3 : -3,
-      deltaMode: 0,
-      bubbles: true,
-      cancelable: true,
-      clientX: e.clientX,
-      clientY: e.clientY,
-    });
-    Object.defineProperty(synth, '__smoothScroll', { value: true });
-    target.dispatchEvent(synth);
+    // Let event through naturally
   };
 
   document.addEventListener('wheel', handler, { capture: true });
@@ -49,6 +47,8 @@ function installScrollHandler() {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────
+
+/** Create a .xterm > .xterm-screen DOM structure and return the inner target */
 function createXtermElement(): HTMLDivElement {
   const xterm = document.createElement('div');
   xterm.classList.add('xterm');
@@ -59,14 +59,18 @@ function createXtermElement(): HTMLDivElement {
   return inner;
 }
 
-function fireWheel(target: HTMLElement, deltaY: number) {
-  const ev = new WheelEvent('wheel', {
-    deltaY,
-    bubbles: true,
-    cancelable: true,
-  });
+/** Fire a wheel event and check if it reaches bubble listeners (i.e. was NOT blocked) */
+function fireWheel(target: HTMLElement, deltaY: number): { passedThrough: boolean; event: WheelEvent } {
+  let passedThrough = false;
+  const bubbleListener = () => { passedThrough = true; };
+  // Listen on parent in bubble phase — only fires if handler didn't stopImmediatePropagation
+  target.parentElement!.addEventListener('wheel', bubbleListener);
+
+  const ev = new WheelEvent('wheel', { deltaY, bubbles: true, cancelable: true });
   target.dispatchEvent(ev);
-  return ev;
+
+  target.parentElement!.removeEventListener('wheel', bubbleListener);
+  return { passedThrough, event: ev };
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -75,6 +79,7 @@ describe('Terminal scroll handler', () => {
   let target: HTMLDivElement;
 
   beforeEach(() => {
+    suppressScroll = false;
     target = createXtermElement();
     cleanup = installScrollHandler();
   });
@@ -84,98 +89,130 @@ describe('Terminal scroll handler', () => {
     target.parentElement?.remove();
   });
 
-  it('should re-dispatch a synthetic event with __smoothScroll flag', () => {
-    const received: WheelEvent[] = [];
-    target.addEventListener('wheel', (e) => received.push(e));
+  // ── Core: first event passes through ──────────────────────────────────
 
-    fireWheel(target, 100);
+  it('should let the first wheel event through (not blocked)', () => {
+    const { passedThrough } = fireWheel(target, 100);
+    expect(passedThrough).toBe(true);
+  });
+
+  it('should preserve the original deltaY on passthrough events', () => {
+    const received: WheelEvent[] = [];
+    // Listen in bubble phase — if event passes through, we see it here
+    target.parentElement!.addEventListener('wheel', (e) => received.push(e));
+
+    fireWheel(target, -250);
 
     expect(received.length).toBe(1);
-    expect((received[0] as any).__smoothScroll).toBe(true);
+    expect(received[0].deltaY).toBe(-250);
   });
 
-  it('should normalize deltaY to ±3 regardless of input magnitude', () => {
-    const received: WheelEvent[] = [];
-    target.addEventListener('wheel', (e) => received.push(e));
+  // ── Throttle: rapid events are blocked ────────────────────────────────
 
-    fireWheel(target, 5000); // extreme momentum value
-    expect(received[0].deltaY).toBe(3);
+  it('should block the second rapid event', () => {
+    fireWheel(target, 50); // first — passes
+    const { passedThrough } = fireWheel(target, 50); // second — blocked
+    expect(passedThrough).toBe(false);
   });
 
-  it('should preserve scroll direction: positive deltaY stays positive', () => {
-    const received: WheelEvent[] = [];
-    target.addEventListener('wheel', (e) => received.push(e));
-
-    fireWheel(target, 100);
-    expect(received[0].deltaY).toBe(3); // positive preserved
+  it('should block many rapid events — only first passes', () => {
+    const results = [];
+    for (let i = 0; i < 10; i++) {
+      results.push(fireWheel(target, 100).passedThrough);
+    }
+    // First passes, rest blocked
+    expect(results[0]).toBe(true);
+    expect(results.slice(1).every(p => p === false)).toBe(true);
   });
 
-  it('should preserve scroll direction: negative deltaY stays negative', () => {
-    const received: WheelEvent[] = [];
-    target.addEventListener('wheel', (e) => received.push(e));
+  it('should allow events again after throttle window expires', async () => {
+    const r1 = fireWheel(target, 50);
+    expect(r1.passedThrough).toBe(true);
 
-    fireWheel(target, -300);
-    expect(received[0].deltaY).toBe(-3); // negative preserved
+    // Wait past throttle
+    await new Promise((r) => setTimeout(r, THROTTLE_MS + 20));
+
+    const r2 = fireWheel(target, 50);
+    expect(r2.passedThrough).toBe(true);
   });
 
-  it('should throttle at 200ms — blocks rapid momentum events', async () => {
-    const received: WheelEvent[] = [];
-    target.addEventListener('wheel', (e) => received.push(e));
+  it('should count bubble listeners receiving events correctly', async () => {
+    const received: number[] = [];
+    target.parentElement!.addEventListener('wheel', (e) => received.push(e.deltaY));
 
-    fireWheel(target, 50);
-    fireWheel(target, 50);
-    fireWheel(target, 50);
+    fireWheel(target, 10);   // passes
+    fireWheel(target, 20);   // blocked
+    fireWheel(target, 30);   // blocked
 
-    // Only the first should pass throttle
-    expect(received.length).toBe(1);
+    await new Promise((r) => setTimeout(r, THROTTLE_MS + 20));
+    fireWheel(target, 40);   // passes
 
-    // Wait past throttle window then fire again
-    await new Promise((r) => setTimeout(r, THROTTLE_MS + 10));
-    fireWheel(target, 50);
-    expect(received.length).toBe(2);
+    expect(received).toEqual([10, 40]);
   });
+
+  // ── Scope: only affects .xterm elements ───────────────────────────────
 
   it('should not intercept wheel events outside .xterm', () => {
     const outside = document.createElement('div');
     document.body.appendChild(outside);
 
-    const prevented: boolean[] = [];
-    outside.addEventListener('wheel', (e) => prevented.push(e.defaultPrevented));
-
+    // Need to add parent listener for fireWheel helper — use manual check
+    let reached = false;
+    outside.addEventListener('wheel', () => { reached = true; });
     const ev = new WheelEvent('wheel', { deltaY: 100, bubbles: true, cancelable: true });
     outside.dispatchEvent(ev);
-
-    expect(prevented.length).toBe(1);
-    expect(prevented[0]).toBe(false);
+    expect(reached).toBe(true);
     outside.remove();
   });
 
-  it('should let __smoothScroll events pass through untouched', () => {
-    const received: WheelEvent[] = [];
-    target.parentElement!.addEventListener('wheel', (e) => received.push(e));
+  it('should not affect events on a separate non-xterm sibling', () => {
+    const sibling = document.createElement('div');
+    sibling.classList.add('toolbar');
+    document.body.appendChild(sibling);
 
-    const synth = new WheelEvent('wheel', {
-      deltaY: 42,
-      bubbles: true,
-      cancelable: true,
-    });
-    Object.defineProperty(synth, '__smoothScroll', { value: true });
-    target.dispatchEvent(synth);
-
-    expect(received.length).toBe(1);
-    expect(received[0].deltaY).toBe(42); // untouched
+    // Use up the throttle on the terminal
+    fireWheel(target, 50);
+    // Sibling event should still pass — check with direct listener
+    let reached = false;
+    sibling.addEventListener('wheel', () => { reached = true; });
+    const ev = new WheelEvent('wheel', { deltaY: 50, bubbles: true, cancelable: true });
+    sibling.dispatchEvent(ev);
+    expect(reached).toBe(true);
+    sibling.remove();
   });
 
-  it('should block original event from reaching parent (stopImmediatePropagation)', () => {
-    const parentReceived: WheelEvent[] = [];
-    // Listen in bubble phase on parent
-    target.parentElement!.addEventListener('wheel', (e) => {
-      if (!(e as any).__smoothScroll) parentReceived.push(e);
-    });
+  // ── suppressScroll: font change protection ────────────────────────────
 
-    fireWheel(target, 100);
+  it('should block ALL events when suppressScroll is true', () => {
+    suppressScroll = true;
+    const { passedThrough } = fireWheel(target, 50);
+    expect(passedThrough).toBe(false);
+  });
 
-    // Parent should only see the synthetic, not the original
-    expect(parentReceived.length).toBe(0);
+  it('should resume after suppressScroll is cleared', () => {
+    suppressScroll = true;
+    fireWheel(target, 50); // blocked
+
+    suppressScroll = false;
+    const { passedThrough } = fireWheel(target, 50);
+    expect(passedThrough).toBe(true);
+  });
+
+  // ── Direction: native events maintain OS scroll direction ─────────────
+
+  it('should pass positive deltaY through unchanged (scroll down)', () => {
+    const received: number[] = [];
+    target.parentElement!.addEventListener('wheel', (e) => received.push(e.deltaY));
+
+    fireWheel(target, 300);
+    expect(received).toEqual([300]);
+  });
+
+  it('should pass negative deltaY through unchanged (scroll up)', () => {
+    const received: number[] = [];
+    target.parentElement!.addEventListener('wheel', (e) => received.push(e.deltaY));
+
+    fireWheel(target, -300);
+    expect(received).toEqual([-300]);
   });
 });


### PR DESCRIPTION
Synthetic WheelEvent re-dispatch never reaches xterm.js internal handlers. New approach: let native events through at throttled rate (150ms), block rapid momentum with stopImmediatePropagation. 13 scroll tests, 29 total.