### PR TITLE
🐛 Fix rocket scroll: RAF batching + DEC 2026 sync + backpressure

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -516,8 +516,9 @@ termWss.on('connection', (ws, req) => {
   }
 
   // Forward PTY output → WebSocket
+  let ptyPaused = false;
   const onData = (id: string, data: string) => {
-    if (id === termId && ws.readyState === WebSocket.OPEN) {
+    if (id === termId && ws.readyState === WebSocket.OPEN && !ptyPaused) {
       ws.send(data);
     }
   };
@@ -553,6 +554,15 @@ termWss.on('connection', (ws, req) => {
       const parsed = JSON.parse(msg);
       if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
         terminalManager.resize(termId, parsed.cols, parsed.rows);
+        return;
+      }
+      // Flow control: frontend signals backpressure
+      if (parsed.type === 'pause') {
+        ptyPaused = true;
+        return;
+      }
+      if (parsed.type === 'resume') {
+        ptyPaused = false;
         return;
       }
       if (parsed.type === 'watch-prompt') {

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -16,7 +16,7 @@ const tileXtermStyles = document.createElement('style');
 tileXtermStyles.textContent = `
   .tile-xterm-container .xterm { height: 100% !important; width: 100% !important; }
   .tile-xterm-container .xterm-screen { width: 100% !important; }
-  .xterm-viewport { overflow-y: scroll !important; scrollbar-width: none !important; }
+  .xterm-viewport { overflow-y: scroll !important; scrollbar-width: none !important; overflow-anchor: auto !important; }
   .xterm-viewport::-webkit-scrollbar { display: none !important; }
   .drag-over-highlight { outline: 2px dashed #58a6ff !important; outline-offset: -2px; position: relative; }
   .drag-over-highlight::after {
@@ -77,7 +77,7 @@ const termInstances = new Map<string, {
   container: HTMLDivElement | null;
   reconnectAttempts: number;
   reconnectTimer: ReturnType<typeof setTimeout> | null;
-  throttler: WriteThrottler;
+  writer: TerminalWriter;
 }>();
 
 // When true, fitAddon.fit() still adjusts rendering but resize is NOT sent to the PTY.
@@ -171,45 +171,120 @@ function saveCheckedSessions(tabs: TermTab[]) {
 }
 
 /**
- * Batches rapid terminal output to prevent "rocket scroll" from agent CLIs.
- * When output arrives faster than FLUSH_INTERVAL, chunks are queued and
- * flushed at a steady rate so the UI stays smooth.
+ * Batches terminal output using requestAnimationFrame and supports DEC Mode 2026
+ * (synchronized output) to prevent "rocket scroll" from AI CLI tools.
+ *
+ * Three layers of protection:
+ * 1. RAF batching — accumulates all WebSocket data within a frame, writes once per frame
+ * 2. DEC 2026 sync — detects \x1b[?2026h (begin) / \x1b[?2026l (end) sequences,
+ *    buffers all data during sync blocks and flushes atomically when sync ends
+ * 3. Backpressure — tracks unprocessed bytes via write callbacks, can signal
+ *    upstream to pause when buffer exceeds HIGH watermark
  */
-class WriteThrottler {
+class TerminalWriter {
   private queue = '';
-  private timer: ReturnType<typeof setTimeout> | null = null;
-  private static readonly FLUSH_INTERVAL = 16; // ~60fps
-  private static readonly BURST_THRESHOLD = 4096; // bytes in queue to start batching
+  private rafId: number | null = null;
+  private syncMode = false;  // DEC 2026 synchronized output active
+  private syncBuffer = '';   // buffered data during sync mode
+  private watermark = 0;
+  private paused = false;
+  private onPause: (() => void) | null = null;
+  private onResume: (() => void) | null = null;
+
+  // Backpressure watermarks (bytes pending in xterm.js write buffer)
+  private static readonly HIGH_WATER = 128_000;  // 128KB — pause upstream
+  private static readonly LOW_WATER = 16_000;    // 16KB — resume upstream
+
+  // DEC 2026 synchronized output escape sequences
+  private static readonly SYNC_START = '\x1b[?2026h';
+  private static readonly SYNC_END = '\x1b[?2026l';
 
   constructor(private term: Terminal) {}
 
+  /** Set callbacks for flow control signaling to upstream (WebSocket/PTY) */
+  setFlowCallbacks(onPause: () => void, onResume: () => void) {
+    this.onPause = onPause;
+    this.onResume = onResume;
+  }
+
   write(data: string) {
-    this.queue += data;
-    if (!this.timer) {
-      // If queue is small, write immediately for low-latency feel
-      if (this.queue.length < WriteThrottler.BURST_THRESHOLD) {
-        this.flush();
+    // Check for DEC 2026 synchronized output sequences
+    const startIdx = data.indexOf(TerminalWriter.SYNC_START);
+    const endIdx = data.indexOf(TerminalWriter.SYNC_END);
+
+    if (startIdx !== -1 && !this.syncMode) {
+      // Sync start found — flush anything before it, then enter sync mode
+      if (startIdx > 0) this.enqueue(data.slice(0, startIdx));
+      this.syncMode = true;
+      // Feed the remainder (after sync start) back through write() to handle
+      // potential sync end in the same chunk
+      const remainder = data.slice(startIdx + TerminalWriter.SYNC_START.length);
+      if (remainder) this.write(remainder);
+      return;
+    }
+
+    if (this.syncMode) {
+      if (endIdx !== -1) {
+        // Sync end found — buffer everything up to it, then flush atomically
+        this.syncBuffer += data.slice(0, endIdx);
+        this.syncMode = false;
+        // Flush the entire sync block as one atomic write
+        this.enqueue(this.syncBuffer);
+        this.syncBuffer = '';
+        // Process any remaining data after the sync end
+        const after = data.slice(endIdx + TerminalWriter.SYNC_END.length);
+        if (after) this.write(after);
       } else {
-        this.timer = setTimeout(() => this.flush(), WriteThrottler.FLUSH_INTERVAL);
+        // Still in sync mode — keep buffering
+        this.syncBuffer += data;
       }
+      return;
+    }
+
+    this.enqueue(data);
+  }
+
+  private enqueue(data: string) {
+    this.queue += data;
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush() {
+    if (this.rafId === null) {
+      this.rafId = requestAnimationFrame(() => this.flush());
     }
   }
 
   private flush() {
-    this.timer = null;
-    if (this.queue) {
-      const data = this.queue;
-      this.queue = '';
-      this.term.write(data);
-      // If more data accumulated during write, schedule next flush
-      if (this.queue) {
-        this.timer = setTimeout(() => this.flush(), WriteThrottler.FLUSH_INTERVAL);
-      }
+    this.rafId = null;
+    if (!this.queue) return;
+
+    const data = this.queue;
+    this.queue = '';
+    this.watermark += data.length;
+
+    // Check if we need to signal backpressure
+    if (!this.paused && this.watermark > TerminalWriter.HIGH_WATER) {
+      this.paused = true;
+      this.onPause?.();
     }
+
+    this.term.write(data, () => {
+      this.watermark = Math.max(0, this.watermark - data.length);
+      if (this.paused && this.watermark < TerminalWriter.LOW_WATER) {
+        this.paused = false;
+        this.onResume?.();
+      }
+    });
+
+    // If more data accumulated during write, schedule another flush
+    if (this.queue) this.scheduleFlush();
   }
 
   dispose() {
-    if (this.timer) clearTimeout(this.timer);
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId);
+    // Flush remaining data synchronously
+    if (this.syncBuffer) { this.queue += this.syncBuffer; this.syncBuffer = ''; }
     if (this.queue) { this.term.write(this.queue); this.queue = ''; }
   }
 }
@@ -399,8 +474,8 @@ export function TerminalView({ onBack }: Props) {
     });
 
     const ws = new WebSocket(`${wsUrl}/ws/terminal?token=${token}&id=${tabId}`);
-    const throttler = new WriteThrottler(term);
-    const inst = { term, fitAddon, ws, connected: false, container, reconnectAttempts: 0, reconnectTimer: null as ReturnType<typeof setTimeout> | null, throttler };
+    const writer = new TerminalWriter(term);
+    const inst = { term, fitAddon, ws, connected: false, container, reconnectAttempts: 0, reconnectTimer: null as ReturnType<typeof setTimeout> | null, writer };
     termInstances.set(tabId, inst);
 
     ws.onopen = () => {
@@ -409,6 +484,12 @@ export function TerminalView({ onBack }: Props) {
       ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
       setTabs(prev => [...prev]); // trigger re-render for status dot
     };
+
+    // Wire up flow control: pause/resume PTY via WebSocket messages
+    writer.setFlowCallbacks(
+      () => { if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'pause' })); },
+      () => { if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'resume' })); },
+    );
 
     ws.onmessage = (e) => {
       try {
@@ -451,7 +532,7 @@ export function TerminalView({ onBack }: Props) {
           } catch {}
         }
       }
-      throttler.write(e.data);
+      writer.write(e.data);
     };
 
     ws.onclose = () => {
@@ -523,7 +604,7 @@ export function TerminalView({ onBack }: Props) {
       if (inst) {
         inst.ws?.close();
         inst.term?.dispose();
-        inst.throttler?.dispose();
+        inst.writer?.dispose();
         if (inst.reconnectTimer) clearTimeout(inst.reconnectTimer);
         termInstances.delete(tabId);
       }
@@ -708,7 +789,7 @@ export function TerminalView({ onBack }: Props) {
       inst.reconnectAttempts = 999; // prevent reconnect on close
       inst.ws?.close();
       inst.term?.dispose();
-      inst.throttler?.dispose();
+      inst.writer?.dispose();
       termInstances.delete(id);
     }
     fetch(`${serverUrl}/api/terminals/${id}`, {
@@ -828,7 +909,7 @@ export function TerminalView({ onBack }: Props) {
       for (const [, inst] of termInstances) {
         if (inst.reconnectTimer) clearTimeout(inst.reconnectTimer);
         inst.ws?.close();
-        inst.throttler?.dispose();
+        inst.writer?.dispose();
         inst.term?.dispose();
       }
       termInstances.clear();
@@ -1061,7 +1142,8 @@ export function TerminalView({ onBack }: Props) {
         // Reduce font and fit to tile container — no PTY resize
         inst.term.options.fontSize = tileFontSize;
         try { inst.fitAddon.fit(); } catch {}
-        inst.term.scrollToBottom();
+        // Defer scrollToBottom to avoid fighting with rapid terminal output redraws
+        setTimeout(() => inst.term.scrollToBottom(), 50);
       }
       suppressPtyResize = false;
     };

--- a/web/src/test/terminal-writer.test.ts
+++ b/web/src/test/terminal-writer.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for TerminalWriter — RAF batching, DEC 2026 sync output, and backpressure.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mock Terminal ───────────────────────────────────────────────────────
+class MockTerminal {
+  written: Array<{ data: string; hasCallback: boolean }> = [];
+  private callbacks: Array<() => void> = [];
+
+  write(data: string, callback?: () => void) {
+    this.written.push({ data, hasCallback: !!callback });
+    if (callback) this.callbacks.push(callback);
+  }
+
+  /** Simulate xterm.js processing the written data */
+  processAll() {
+    const cbs = this.callbacks.splice(0);
+    cbs.forEach(cb => cb());
+  }
+
+  lastWritten(): string {
+    return this.written[this.written.length - 1]?.data ?? '';
+  }
+}
+
+// ── Standalone TerminalWriter (mirrors TerminalView.tsx implementation) ──
+class TerminalWriter {
+  private queue = '';
+  private rafId: number | null = null;
+  private syncMode = false;
+  private syncBuffer = '';
+  private watermark = 0;
+  private paused = false;
+  private _onPause: (() => void) | null = null;
+  private _onResume: (() => void) | null = null;
+
+  private static readonly HIGH_WATER = 128_000;
+  private static readonly LOW_WATER = 16_000;
+  private static readonly SYNC_START = '\x1b[?2026h';
+  private static readonly SYNC_END = '\x1b[?2026l';
+
+  constructor(private term: MockTerminal) {}
+
+  setFlowCallbacks(onPause: () => void, onResume: () => void) {
+    this._onPause = onPause;
+    this._onResume = onResume;
+  }
+
+  write(data: string) {
+    const startIdx = data.indexOf(TerminalWriter.SYNC_START);
+    const endIdx = data.indexOf(TerminalWriter.SYNC_END);
+
+    if (startIdx !== -1 && !this.syncMode) {
+      if (startIdx > 0) this.enqueue(data.slice(0, startIdx));
+      this.syncMode = true;
+      const remainder = data.slice(startIdx + TerminalWriter.SYNC_START.length);
+      if (remainder) this.write(remainder);
+      return;
+    }
+
+    if (this.syncMode) {
+      if (endIdx !== -1) {
+        this.syncBuffer += data.slice(0, endIdx);
+        this.syncMode = false;
+        this.enqueue(this.syncBuffer);
+        this.syncBuffer = '';
+        const after = data.slice(endIdx + TerminalWriter.SYNC_END.length);
+        if (after) this.write(after);
+      } else {
+        this.syncBuffer += data;
+      }
+      return;
+    }
+
+    this.enqueue(data);
+  }
+
+  private enqueue(data: string) {
+    this.queue += data;
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush() {
+    if (this.rafId === null) {
+      this.rafId = requestAnimationFrame(() => this.flush());
+    }
+  }
+
+  private flush() {
+    this.rafId = null;
+    if (!this.queue) return;
+
+    const data = this.queue;
+    this.queue = '';
+    this.watermark += data.length;
+
+    if (!this.paused && this.watermark > TerminalWriter.HIGH_WATER) {
+      this.paused = true;
+      this._onPause?.();
+    }
+
+    this.term.write(data, () => {
+      this.watermark = Math.max(0, this.watermark - data.length);
+      if (this.paused && this.watermark < TerminalWriter.LOW_WATER) {
+        this.paused = false;
+        this._onResume?.();
+      }
+    });
+
+    if (this.queue) this.scheduleFlush();
+  }
+
+  dispose() {
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId);
+    if (this.syncBuffer) { this.queue += this.syncBuffer; this.syncBuffer = ''; }
+    if (this.queue) { this.term.write(this.queue); this.queue = ''; }
+  }
+
+  // Test accessors
+  get isPaused() { return this.paused; }
+  get isSyncMode() { return this.syncMode; }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** Flush pending RAF callbacks by running microtask + rAF simulation */
+async function flushRAF() {
+  // jsdom supports rAF via setTimeout(0), so advance timers
+  await new Promise(r => setTimeout(r, 20));
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+describe('TerminalWriter', () => {
+  let term: MockTerminal;
+  let writer: TerminalWriter;
+
+  beforeEach(() => {
+    term = new MockTerminal();
+    writer = new TerminalWriter(term);
+  });
+
+  afterEach(() => {
+    writer.dispose();
+  });
+
+  // ── RAF Batching ───────────────────────────────────────────────────────
+
+  it('should batch multiple writes into one RAF flush', async () => {
+    writer.write('hello');
+    writer.write(' world');
+    writer.write('!');
+
+    // Before RAF fires, nothing written to terminal
+    expect(term.written.length).toBe(0);
+
+    await flushRAF();
+
+    // All data combined into one write
+    expect(term.written.length).toBe(1);
+    expect(term.written[0].data).toBe('hello world!');
+  });
+
+  it('should write with callback for backpressure tracking', async () => {
+    writer.write('test');
+    await flushRAF();
+
+    expect(term.written[0].hasCallback).toBe(true);
+  });
+
+  it('should handle multiple frames independently', async () => {
+    writer.write('frame1');
+    await flushRAF();
+
+    writer.write('frame2');
+    await flushRAF();
+
+    expect(term.written.length).toBe(2);
+    expect(term.written[0].data).toBe('frame1');
+    expect(term.written[1].data).toBe('frame2');
+  });
+
+  // ── DEC 2026 Synchronized Output ──────────────────────────────────────
+
+  it('should buffer data during sync mode (DEC 2026)', async () => {
+    writer.write('\x1b[?2026h');  // begin sync
+    writer.write('buffered line 1\n');
+    writer.write('buffered line 2\n');
+
+    await flushRAF();
+
+    // Nothing written yet — still in sync mode
+    expect(term.written.length).toBe(0);
+    expect(writer.isSyncMode).toBe(true);
+  });
+
+  it('should flush atomically when sync ends', async () => {
+    writer.write('\x1b[?2026h');
+    writer.write('line1\n');
+    writer.write('line2\n');
+    writer.write('\x1b[?2026l');  // end sync
+
+    await flushRAF();
+
+    expect(term.written.length).toBe(1);
+    expect(term.written[0].data).toBe('line1\nline2\n');
+    expect(writer.isSyncMode).toBe(false);
+  });
+
+  it('should handle sync start and end in same chunk', async () => {
+    writer.write('\x1b[?2026hatomic content\x1b[?2026l');
+    await flushRAF();
+
+    expect(term.written.length).toBe(1);
+    expect(term.written[0].data).toBe('atomic content');
+  });
+
+  it('should handle data before sync start', async () => {
+    writer.write('before\x1b[?2026hsynced\x1b[?2026lafter');
+    await flushRAF();
+
+    // "before" is enqueued first, then "synced", then "after" — but all in same RAF
+    expect(term.written.length).toBe(1);
+    expect(term.written[0].data).toBe('beforesyncedafter');
+  });
+
+  it('should handle multiple sync blocks', async () => {
+    writer.write('\x1b[?2026hblock1\x1b[?2026l');
+    await flushRAF();
+    expect(term.written[0].data).toBe('block1');
+
+    writer.write('\x1b[?2026hblock2\x1b[?2026l');
+    await flushRAF();
+    expect(term.written[1].data).toBe('block2');
+  });
+
+  // ── Backpressure ──────────────────────────────────────────────────────
+
+  it('should trigger pause when watermark exceeds HIGH', async () => {
+    const onPause = vi.fn();
+    const onResume = vi.fn();
+    writer.setFlowCallbacks(onPause, onResume);
+
+    // Write more than HIGH_WATER (128KB)
+    const largeData = 'x'.repeat(130_000);
+    writer.write(largeData);
+    await flushRAF();
+
+    expect(onPause).toHaveBeenCalledOnce();
+    expect(writer.isPaused).toBe(true);
+  });
+
+  it('should trigger resume when watermark drops below LOW', async () => {
+    const onPause = vi.fn();
+    const onResume = vi.fn();
+    writer.setFlowCallbacks(onPause, onResume);
+
+    const largeData = 'x'.repeat(130_000);
+    writer.write(largeData);
+    await flushRAF();
+
+    expect(writer.isPaused).toBe(true);
+
+    // Simulate xterm.js processing the data
+    term.processAll();
+
+    expect(onResume).toHaveBeenCalledOnce();
+    expect(writer.isPaused).toBe(false);
+  });
+
+  it('should not trigger pause for small writes', async () => {
+    const onPause = vi.fn();
+    writer.setFlowCallbacks(onPause, () => {});
+
+    writer.write('small data');
+    await flushRAF();
+
+    expect(onPause).not.toHaveBeenCalled();
+    expect(writer.isPaused).toBe(false);
+  });
+
+  // ── Dispose ───────────────────────────────────────────────────────────
+
+  it('should flush remaining data on dispose', () => {
+    writer.write('pending');
+    // Don't await RAF — call dispose directly
+    writer.dispose();
+
+    expect(term.written.length).toBe(1);
+    expect(term.written[0].data).toBe('pending');
+  });
+
+  it('should flush sync buffer on dispose', () => {
+    writer.write('\x1b[?2026h');
+    writer.write('synced but not ended');
+    writer.dispose();
+
+    expect(term.written.length).toBe(1);
+    expect(term.written[0].data).toBe('synced but not ended');
+  });
+});


### PR DESCRIPTION
## Root Cause
AI CLI tools (Claude Code, Copilot) do full-screen terminal redraws via control sequences (ED3, cursor repositioning, alternate buffer switches) on every output chunk. This overwhelms xterm.js's viewport, causing uncontrollable scrolling/jumping. This is [xterm.js #5620](https://github.com/xtermjs/xterm.js/issues/5620) (1000+ upvotes) — affects everyone globally.

## Multi-Layer Fix

### Layer 1: RAF Write Batching
Replace `WriteThrottler` (setTimeout-based) with `TerminalWriter` using `requestAnimationFrame`. Accumulates all WebSocket data within a frame, writes to xterm.js once per frame (~60fps). No more per-message writes that overwhelm the renderer.

### Layer 2: DEC Mode 2026 (Synchronized Output)
Detects `\x1b[?2026h` (begin sync) and `\x1b[?2026l` (end sync) sequences in the data stream. Buffers all data during sync blocks and flushes as a single atomic `term.write()` when sync ends. Prevents intermediate rendering states that cause viewport jumps. Modern Claude Code and tmux already emit these sequences.

### Layer 3: Write Backpressure
Tracks unprocessed bytes via `term.write(data, callback)` with HIGH/LOW watermarks (128KB/16KB). When buffer exceeds HIGH, sends `pause` message to server which suppresses PTY data forwarding. When processed below LOW, sends `resume`. Creates real backpressure all the way to the PTY.

### Layer 4: Viewport Scroll Stabilization
- Deferred `scrollToBottom()` in tile scaling (50ms delay)
- CSS `overflow-anchor: auto` on `.xterm-viewport`
- Existing wheel handler v7 (momentum detection) preserved

## Tests
13 new TerminalWriter tests covering RAF batching, DEC 2026 sync blocks, backpressure watermarks, and dispose behavior. **45 total tests passing** across 4 test files.