### PR TITLE
✨ LLM-summarized session titles

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -409,6 +409,70 @@ app.delete('/api/tmux-sessions/:name', (req, res) => {
   res.json({ killed });
 });
 
+// Terminal session summarization — uses ACP to generate a short title from pane content
+app.post('/api/terminals/:id/summarize', async (req, res) => {
+  const terminal = terminalManager.get(req.params.id);
+  if (!terminal) {
+    res.status(404).json({ error: 'Terminal not found' });
+    return;
+  }
+
+  const paneContent = terminalManager.capturePaneContent(terminal.tmuxSession);
+  if (!paneContent) {
+    res.status(400).json({ error: 'No terminal content available' });
+    return;
+  }
+
+  const summarizePrompt = `Summarize what the user is doing in this terminal session in 5 words or less. Return ONLY the short title, no explanation or quotes.\n\nTerminal output:\n${paneContent}`;
+  const sessionId = `_summarize_${Date.now()}`;
+  let result = '';
+  let responded = false;
+
+  const cleanup = () => {
+    acpManager.off('chunk', chunkHandler);
+    acpManager.off('turn_complete', doneHandler);
+    acpManager.off('error', errorHandler);
+    acpManager.destroy(sessionId);
+  };
+  const respond = (data: object) => {
+    if (responded) return;
+    responded = true;
+    cleanup();
+    clearTimeout(timeout);
+    res.json(data);
+  };
+
+  const chunkHandler = (sid: string, text: string) => {
+    if (sid === sessionId) result += text;
+  };
+  const doneHandler = (sid: string) => {
+    if (sid === sessionId) {
+      const title = result.trim().replace(/^["']|["']$/g, '') || 'Terminal';
+      respond({ title });
+    }
+  };
+  const errorHandler = (sid: string, err: unknown) => {
+    if (sid === sessionId) {
+      const msg = err instanceof Error ? err.message : String(err);
+      respond({ title: null, error: msg });
+    }
+  };
+
+  const timeout = setTimeout(() => {
+    respond({ title: result.trim().replace(/^["']|["']$/g, '') || null, error: 'timeout' });
+  }, 15_000);
+
+  acpManager.on('chunk', chunkHandler);
+  acpManager.on('turn_complete', (sid: string) => doneHandler(sid));
+  acpManager.on('error', (sid: string, err: unknown) => errorHandler(sid, err));
+
+  try {
+    await acpManager.sendPrompt(sessionId, summarizePrompt);
+  } catch (err: any) {
+    respond({ title: null, error: err.message });
+  }
+});
+
 // Todo queue REST endpoints
 app.get('/api/todos', (_req, res) => {
   res.json(getTodos());

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -224,6 +224,20 @@ class TerminalManager extends EventEmitter {
     }
   }
 
+  /** Capture the visible pane content for a tmux session (last N chars) */
+  capturePaneContent(sessionName: string, maxChars = 2000): string {
+    if (!TMUX_PATH) return '';
+    try {
+      const content = execSync(
+        `${TMUX_PATH} capture-pane -t "${sessionName}" -p -S -50`,
+        { encoding: 'utf8', timeout: 3000 },
+      ).trim();
+      return content.slice(-maxChars);
+    } catch {
+      return '';
+    }
+  }
+
   /** Get the current command running in a tmux session's active pane */
   getTmuxPaneCommand(sessionName: string): string {
     if (!TMUX_PATH) return '';

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -3,7 +3,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Box, IconButton, Text, ActionMenu, ActionList } from '@primer/react';
-import { PlusIcon, XIcon, ArrowLeftIcon, AppsIcon, LinkIcon, PencilIcon, TrashIcon, ListUnorderedIcon, GlobeIcon, EyeIcon } from '@primer/octicons-react';
+import { PlusIcon, XIcon, ArrowLeftIcon, AppsIcon, LinkIcon, PencilIcon, TrashIcon, ListUnorderedIcon, GlobeIcon, EyeIcon, SparkleIcon } from '@primer/octicons-react';
 import { useTodoDispatcher } from '../hooks/useTodoDispatcher';
 import { useSwarmStatus } from '../hooks/useSwarmStatus';
 import { api } from '../lib/api';
@@ -340,6 +340,25 @@ export function TerminalView({ onBack }: Props) {
   activeTabIdRef.current = activeTabId;
   const globalFontSizeRef = useRef(globalFontSize);
   globalFontSizeRef.current = globalFontSize;
+  const [summarizingTabId, setSummarizingTabId] = useState<string | null>(null);
+  const autoSummarizedRef = useRef<Set<string>>(new Set());
+
+  /** Ask the server to summarize a terminal's content using AI */
+  const summarizeTab = useCallback(async (tabId: string) => {
+    setSummarizingTabId(tabId);
+    try {
+      const result = await api.summarizeTerminal(tabId);
+      if (result.title) {
+        const tab = tabsRef.current.find(t => t.id === tabId);
+        setTabs(prev => prev.map(t => t.id === tabId ? { ...t, name: result.title!, userRenamed: true } : t));
+        if (tab?.tmuxSession) setCachedTabName(tab.tmuxSession, result.title);
+      }
+    } catch (err) {
+      console.debug('[Summarize] Failed:', err);
+    } finally {
+      setSummarizingTabId(null);
+    }
+  }, []);
 
   // Persist tile mode and checked tiles to localStorage
   useEffect(() => {
@@ -514,6 +533,12 @@ export function TerminalView({ onBack }: Props) {
         if (parsed.type === 'prompt') {
           // Shell prompt returned — notify todo dispatcher
           todoDispatcherRef.current.onTilePromptReturned(tabId);
+          // Auto-summarize on first prompt detection per tab (if not user-renamed)
+          const tab = tabsRef.current.find(t => t.id === tabId);
+          if (tab && !tab.userRenamed && !autoSummarizedRef.current.has(tabId)) {
+            autoSummarizedRef.current.add(tabId);
+            summarizeTab(tabId);
+          }
           return;
         }
       } catch (_parseErr) { /* raw terminal data */ }
@@ -1408,6 +1433,16 @@ export function TerminalView({ onBack }: Props) {
                     sx={{ bg: 'transparent', border: 'none', color: 'fg.muted', cursor: 'pointer', p: 0, ml: 1, display: 'flex', flexShrink: 0, ':hover': { color: 'accent.fg' } }}
                   >
                     <ListUnorderedIcon size={12} />
+                  </Box>
+                )}
+                {tab.tmuxSession && (
+                  <Box
+                    as="button"
+                    onClick={(e: React.MouseEvent) => { e.stopPropagation(); summarizeTab(tab.id); }}
+                    title="AI summarize session"
+                    sx={{ bg: 'transparent', border: 'none', color: summarizingTabId === tab.id ? 'accent.fg' : 'fg.muted', cursor: 'pointer', p: 0, ml: 1, display: 'flex', flexShrink: 0, opacity: summarizingTabId === tab.id ? 0.6 : 1, ':hover': { color: 'accent.fg' } }}
+                  >
+                    <SparkleIcon size={12} />
                   </Box>
                 )}
                 {tab.tmuxSession && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -58,6 +58,9 @@ export const api = {
   saveTodos: (items: TodoItem[], todoMode: boolean) =>
     request<{ ok: boolean }>('/api/todos', { method: 'PUT', body: JSON.stringify({ items, todoMode }) }),
 
+  summarizeTerminal: (id: string) =>
+    request<{ title: string | null; error?: string }>(`/api/terminals/${id}/summarize`, { method: 'POST' }),
+
   /** Upload a file (drag-drop image) to the server and return its filesystem path */
   uploadFile: async (file: File): Promise<{ path: string }> => {
     const buffer = await file.arrayBuffer();


### PR DESCRIPTION
## Summary

Adds AI-powered session title summarization for terminal tabs.

### Changes

**Server-side:**
- `POST /api/terminals/:id/summarize` endpoint that captures tmux pane content (last ~2000 chars) and sends it to ACP with a prompt for a 5-word-or-less summary. 15s timeout with graceful fallback.
- `capturePaneContent()` method on terminal-manager using `tmux capture-pane`

**Web UI:**
- ✨ Sparkle button on each terminal tab to manually trigger AI summarization
- Auto-summarize on first prompt detection (only for tabs not user-renamed)
- Summarized title persists via localStorage tab name cache

**Fallback:** If ACP/AI is unavailable, the existing session name is preserved.

### Testing
- All 90 server tests pass
- All 45 web tests pass
- Server TypeScript builds cleanly