### PR TITLE
🐛 Use COPILOT_PAT for Copilot agent assignment

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,4 +23,4 @@ jobs:
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.COPILOT_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The AI Fix workflow fails with `Forbidden` when trying to assign `copilot-swe-agent[bot]` to issues. The default `GITHUB_TOKEN` doesn't have the required scopes for Copilot coding agent assignment.

## Fix
Use `COPILOT_PAT` secret (a PAT with appropriate scopes) with fallback to `GITHUB_TOKEN`.

## Verification
- Manually assigned Copilot to issues #124, #123, #122, #67, #23 using PAT — all succeeded
- `COPILOT_PAT` secret has been added to the repo