### PR TITLE
🐛 Add missing @agentclientprotocol/sdk to server dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.14.1.tgz",
+      "integrity": "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
     "node_modules/@apideck/better-ajv-errors": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.6.tgz",
@@ -10838,6 +10847,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -10853,6 +10872,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@agentclientprotocol/sdk": "^0.14.1",
         "express": "^5.1.0",
         "node-pty": "^1.1.0",
         "uuid": "^11.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "postinstall": "chmod +x ../node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^0.14.1",
     "express": "^5.1.0",
     "node-pty": "^1.1.0",
     "uuid": "^11.1.0",


### PR DESCRIPTION
ACP SDK was imported but not in server/package.json, causing build failures on clean installs and dirty git state on deployed instances.