### PR TITLE
🌱 Make prompt edit modal textarea taller

### DIFF
--- a/web/src/components/TodoPanel.tsx
+++ b/web/src/components/TodoPanel.tsx
@@ -686,9 +686,9 @@ export default function TodoPanel({
                 }
                 e.stopPropagation();
               }}
-              rows={8}
+              rows={16}
               style={{
-                width: '100%', padding: '8px 10px', borderRadius: 6,
+                width: '100%', flex: 1, minHeight: 300, padding: '8px 10px', borderRadius: 6,
                 border: '1px solid var(--borderColor-default, #30363d)',
                 background: 'var(--bgColor-inset, #010409)',
                 color: 'var(--fgColor-default, #e6edf3)',


### PR DESCRIPTION
Textarea now fills the modal height (rows 8→16, flex:1, minHeight:300px)