### PR TITLE
🐛 Fix intermittent rocket scroll: PTY-level backpressure

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -661,12 +661,18 @@ termWss.on('connection', (ws, req) => {
     return;
   }
 
-  // Forward PTY output → WebSocket
+  // Forward PTY output → WebSocket (with backpressure support)
   let ptyPaused = false;
+  let pauseBuffer = '';  // buffer data arriving between pause signal and PTY actually stopping
   const onData = (id: string, data: string) => {
-    if (id === termId && ws.readyState === WebSocket.OPEN && !ptyPaused) {
-      ws.send(data);
+    if (id !== termId || ws.readyState !== WebSocket.OPEN) return;
+    if (ptyPaused) {
+      // PTY may emit a few more events after pause() is called (already-queued reads).
+      // Buffer them instead of dropping so no data is lost.
+      pauseBuffer += data;
+      return;
     }
+    ws.send(data);
   };
   const onExit = (id: string, exitCode: number) => {
     if (id === termId && ws.readyState === WebSocket.OPEN) {
@@ -702,13 +708,21 @@ termWss.on('connection', (ws, req) => {
         terminalManager.resize(termId, parsed.cols, parsed.rows);
         return;
       }
-      // Flow control: frontend signals backpressure
+      // Flow control: frontend signals backpressure — pause/resume the PTY stream
+      // so the kernel buffer fills and the writing process naturally throttles
       if (parsed.type === 'pause') {
         ptyPaused = true;
+        terminalManager.pause(termId);
         return;
       }
       if (parsed.type === 'resume') {
         ptyPaused = false;
+        // Flush any data that was buffered during the pause
+        if (pauseBuffer) {
+          ws.send(pauseBuffer);
+          pauseBuffer = '';
+        }
+        terminalManager.resume(termId);
         return;
       }
       if (parsed.type === 'watch-prompt') {
@@ -726,6 +740,12 @@ termWss.on('connection', (ws, req) => {
   });
 
   ws.on('close', () => {
+    // Resume PTY if it was paused — prevents stale pause on reconnect
+    if (ptyPaused) {
+      terminalManager.resume(termId);
+      ptyPaused = false;
+      pauseBuffer = '';
+    }
     terminalManager.removeListener('data', onData);
     terminalManager.removeListener('exit', onExit);
     terminalManager.removeListener('command', onCommand);

--- a/server/src/terminal-manager.ts
+++ b/server/src/terminal-manager.ts
@@ -251,6 +251,18 @@ class TerminalManager extends EventEmitter {
     }
   }
 
+  /** Pause reading from the PTY stream (OS-level backpressure) */
+  pause(id: string): void {
+    const t = this.terminals.get(id);
+    if (t) t.pty.pause();
+  }
+
+  /** Resume reading from the PTY stream */
+  resume(id: string): void {
+    const t = this.terminals.get(id);
+    if (t) t.pty.resume();
+  }
+
   write(id: string, data: string): boolean {
     const t = this.terminals.get(id);
     if (!t) return false;


### PR DESCRIPTION
## Summary
- Layer 4 backpressure was silently **dropping PTY data** when the client signaled pause — `node-pty` kept reading/emitting events that were discarded
- On resume, the terminal received data mid-stream with gaps → garbled redraws → feedback loop → intermittent rocket scroll
- Now calls `pty.pause()` / `pty.resume()` for real OS-level backpressure: kernel PTY buffer fills, writing process blocks, **zero data loss**
- Any in-flight data (already-queued events before pause takes effect) is buffered and flushed on resume
- PTY is always resumed on WebSocket close to prevent stale pauses on reconnect

## Changes
- `server/src/terminal-manager.ts`: Add `pause(id)` / `resume(id)` methods that call node-pty's native stream control
- `server/src/index.ts`: Replace data-dropping flag with PTY pause + in-flight buffer + flush-on-resume

## Test plan
- [ ] Start Copilot in autopilot mode with sustained heavy output
- [ ] Verify no rocket scroll during rapid screen redraws
- [ ] Verify terminal content is complete (no gaps/garbled output) after bursts
- [ ] Verify reconnection works (PTY resumes on WS close)