### PR TITLE
🐛 Fix rocket scroll: viewport scroll lock during screen-clearing writes

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -190,6 +190,7 @@ class TerminalWriter {
   private paused = false;
   private onPause: (() => void) | null = null;
   private onResume: (() => void) | null = null;
+  private viewport: HTMLElement | null = null;  // cached .xterm-viewport element
 
   // Backpressure watermarks (bytes pending in xterm.js write buffer)
   private static readonly HIGH_WATER = 128_000;  // 128KB — pause upstream
@@ -198,6 +199,9 @@ class TerminalWriter {
   // DEC 2026 synchronized output escape sequences
   private static readonly SYNC_START = '\x1b[?2026h';
   private static readonly SYNC_END = '\x1b[?2026l';
+
+  // Screen-clearing ANSI sequences that cause viewport jumps during progressive rendering
+  private static readonly SCREEN_CLEAR_RE = /\x1b\[\d*J|\x1b\[H/;
 
   constructor(private term: Terminal) {}
 
@@ -269,7 +273,29 @@ class TerminalWriter {
       this.onPause?.();
     }
 
+    // Viewport scroll lock: if the batch contains screen-clearing sequences (ED, cursor home),
+    // xterm.js will jump the viewport during progressive rendering of the batch.
+    // Lock the viewport at its current position during the write, then snap to bottom
+    // in the callback (if user was already at the bottom).
+    const vp = this.getViewport();
+    const hasScreenClear = TerminalWriter.SCREEN_CLEAR_RE.test(data);
+    let wasAtBottom = false;
+    if (hasScreenClear && vp) {
+      const BOTTOM_THRESHOLD_PX = 5; // within 5px of bottom counts as "at bottom"
+      wasAtBottom = vp.scrollTop >= (vp.scrollHeight - vp.clientHeight - BOTTOM_THRESHOLD_PX);
+      // Freeze: prevent scroll position changes during write
+      vp.style.overflowY = 'hidden';
+    }
+
     this.term.write(data, () => {
+      // Unfreeze viewport and restore scroll position
+      if (hasScreenClear && vp) {
+        vp.style.overflowY = '';
+        if (wasAtBottom) {
+          // Snap to bottom — user was following output
+          vp.scrollTop = vp.scrollHeight;
+        }
+      }
       this.watermark = Math.max(0, this.watermark - data.length);
       if (this.paused && this.watermark < TerminalWriter.LOW_WATER) {
         this.paused = false;
@@ -279,6 +305,14 @@ class TerminalWriter {
 
     // If more data accumulated during write, schedule another flush
     if (this.queue) this.scheduleFlush();
+  }
+
+  /** Lazily find and cache the .xterm-viewport element */
+  private getViewport(): HTMLElement | null {
+    if (!this.viewport) {
+      this.viewport = this.term.element?.querySelector('.xterm-viewport') as HTMLElement | null;
+    }
+    return this.viewport;
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- During heavy AI CLI output (Copilot autopilot), RAF-batched writes containing screen-clearing ANSI sequences (`\x1b[nJ`, `\x1b[H`) cause xterm.js to progressively render intermediate states, bouncing the viewport scroll position = intermittent rocket scroll
- Backpressure watermarks never trigger (confirmed via runtime monitoring), so the PTY-level fix in PR #184 was necessary but insufficient
- **Fix**: Detect screen-clearing sequences in the batch, freeze the `.xterm-viewport` (`overflow:hidden`) before `term.write()`, then restore and snap to bottom in the write callback

## How it works
1. Before each `flush()`, check if the batched data contains screen-clearing ANSI sequences via regex
2. If yes, check if user is "at bottom" (within 5px threshold)
3. Set `overflow-y: hidden` on the viewport to prevent scroll position changes during progressive rendering
4. In the `term.write()` callback (after rendering completes), restore `overflow-y` and snap to bottom if user was following output
5. The viewport element is lazily cached to avoid repeated DOM queries

## Test plan
- [ ] Run Copilot in autopilot mode with sustained heavy output — verify no viewport oscillation
- [ ] Verify normal trackpad scrolling still works in all terminal tiles
- [ ] Verify scroll-up to read history is preserved (viewport should NOT auto-snap when user is scrolled up)
- [ ] Verify reconnection/tile switching still works correctly