### PR TITLE
🐛 Remove suppressScroll from scaleTiles — fixes tile scroll regression

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1151,7 +1151,6 @@ export const TerminalView = memo(function TerminalView({ onBack }: Props) {
         : Math.max(MIN_FONT_SIZE, base - 1);
 
       suppressPtyResize = true;
-      suppressScroll = true;
       for (const tab of checked) {
         const container = containerRefs.current.get(tab.id);
         if (!container || !container.isConnected) continue;
@@ -1176,8 +1175,6 @@ export const TerminalView = memo(function TerminalView({ onBack }: Props) {
         }
       }
       suppressPtyResize = false;
-      // Re-enable scroll after a brief delay to let xterm settle
-      setTimeout(() => { suppressScroll = false; }, 300);
     };
 
     // Apply after layout settles (two rAFs for grid to be fully rendered)


### PR DESCRIPTION
Fixes inability to scroll inside tiles.

**Root cause:** PR #190 added `suppressScroll = true` in `scaleTiles()`, but this effect re-runs on every `activeTabId` change (clicking a tile). This blocked wheel events for 300ms each time, making tile scrolling unreliable.

**Fix:** Remove `suppressScroll` from `scaleTiles()`. The wheel blocker is only needed during font-size changes (already handled in the `globalFontSize` effect).