### PR TITLE
🐛 Fix Cmd+/- font size shortcuts blocked by xterm key handler

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -547,6 +547,8 @@ export const TerminalView = memo(function TerminalView({ onBack }: Props) {
         term.selectAll();
         return false;
       }
+      // Font size: let window keydown handler process Cmd+=/+/-/0
+      if (e.key === '=' || e.key === '+' || e.key === '-' || e.key === '0') return false;
       return true;
     });
 


### PR DESCRIPTION
xterm's custom key handler returned `true` for Cmd+=/+/-/0, consuming these events before the window keydown handler could process them for font size changes. Now returns `false` so they bypass xterm.