### PR TITLE
🐛 Add viewport scroll lock to prevent rocket scroll in alternate screen

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -195,6 +195,7 @@ class TerminalWriter {
   private onPause: (() => void) | null = null;
   private onResume: (() => void) | null = null;
   private viewport: HTMLElement | null = null;  // cached .xterm-viewport element
+  private scrollHandler: (() => void) | null = null;  // alt-screen scroll lock handler
 
   // Backpressure watermarks (bytes pending in xterm.js write buffer)
   private static readonly HIGH_WATER = 128_000;  // 128KB — pause upstream
@@ -204,7 +205,23 @@ class TerminalWriter {
   private static readonly SYNC_START = '\x1b[?2026h';
   private static readonly SYNC_END = '\x1b[?2026l';
 
-  constructor(private term: Terminal) {}
+  constructor(private term: Terminal) {
+    // Install a viewport scroll lock: in alternate screen mode, xterm.js v6 may
+    // auto-scroll to the cursor position during async write processing. A persistent
+    // scroll event listener catches this BEFORE the browser paints the next frame,
+    // preventing the "rocket scroll" visual artifact in tile mode.
+    requestAnimationFrame(() => {
+      const vp = this.getViewport();
+      if (vp) {
+        this.scrollHandler = () => {
+          if (this.term.buffer.active.type === 'alternate' && vp.scrollTop !== 0) {
+            vp.scrollTop = 0;
+          }
+        };
+        vp.addEventListener('scroll', this.scrollHandler, { passive: true });
+      }
+    });
+  }
 
   /** Set callbacks for flow control signaling to upstream (WebSocket/PTY) */
   setFlowCallbacks(onPause: () => void, onResume: () => void) {
@@ -274,9 +291,6 @@ class TerminalWriter {
       this.onPause?.();
     }
 
-    // Detect alternate screen mode (tmux, vim, less, AI tools like Claude Code)
-    const inAlternateScreen = this.term.buffer.active.type === 'alternate';
-
     // Viewport scroll stabilization: xterm.js auto-scrolls to the bottom on
     // every write. In alternate screen mode, force scrollTop=0 to prevent
     // transient scroll jumps during rapid redraws. In normal mode, save/restore
@@ -291,8 +305,11 @@ class TerminalWriter {
     }
 
     this.term.write(data, () => {
+      // Re-check alternate screen at callback time — xterm v6 may process writes
+      // asynchronously, and the buffer type could change between enqueue and callback.
+      const altScreenNow = this.term.buffer.active.type === 'alternate';
       if (vp) {
-        if (inAlternateScreen) {
+        if (altScreenNow) {
           // Alternate screen: force scrollTop to 0 — there should be no scrollback,
           // but xterm.js may transiently create rows during rapid redraws
           const scrollWasNonZero = vp.scrollTop !== 0;
@@ -331,6 +348,11 @@ class TerminalWriter {
 
   dispose() {
     if (this.rafId !== null) cancelAnimationFrame(this.rafId);
+    // Remove scroll lock handler
+    if (this.scrollHandler && this.viewport) {
+      this.viewport.removeEventListener('scroll', this.scrollHandler);
+      this.scrollHandler = null;
+    }
     // Flush remaining data synchronously
     if (this.syncBuffer) { this.queue += this.syncBuffer; this.syncBuffer = ''; }
     if (this.queue) { this.term.write(this.queue); this.queue = ''; }
@@ -1167,8 +1189,14 @@ export const TerminalView = memo(function TerminalView({ onBack }: Props) {
         try { inst.fitAddon.fit(); } catch {}
         // Only scroll to bottom in normal screen mode; alternate screen uses
         // scrollTop=0 enforced by TerminalWriter — scrollToBottom() causes rocket scroll.
+        // Re-check buffer type inside timeout to avoid race with screen transitions.
+        const capturedInst = inst;
         if (inst.term.buffer.active.type !== 'alternate') {
-          setTimeout(() => inst.term.scrollToBottom(), 50);
+          setTimeout(() => {
+            if (capturedInst.term.buffer.active.type !== 'alternate') {
+              capturedInst.term.scrollToBottom();
+            }
+          }, 50);
         }
       }
       suppressPtyResize = false;

--- a/web/src/test/terminal-scroll.test.ts
+++ b/web/src/test/terminal-scroll.test.ts
@@ -269,3 +269,100 @@ describe('Terminal scroll handler', () => {
     xterm2.remove();
   });
 });
+
+// ── Viewport scroll lock for alternate screen ───────────────────────
+describe('Viewport scroll lock (alternate screen)', () => {
+  /**
+   * Regression test: xterm.js v6 processes writes asynchronously — between
+   * enqueue and the write callback, the browser may paint a frame where
+   * xterm auto-scrolled the viewport to the cursor. A persistent scroll
+   * event listener on .xterm-viewport enforces scrollTop=0 in alternate
+   * screen mode, preventing the "rocket scroll" visual artifact.
+   */
+
+  let viewport: HTMLDivElement;
+  let cleanup: () => void;
+
+  // Minimal mock for the scroll lock handler — mirrors TerminalWriter constructor logic
+  function installScrollLock(
+    vp: HTMLElement,
+    getBufferType: () => string
+  ) {
+    const handler = () => {
+      if (getBufferType() === 'alternate' && vp.scrollTop !== 0) {
+        vp.scrollTop = 0;
+      }
+    };
+    vp.addEventListener('scroll', handler, { passive: true });
+    return () => vp.removeEventListener('scroll', handler);
+  }
+
+  beforeEach(() => {
+    const { viewport: vp } = createXtermElement();
+    viewport = vp;
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    viewport?.closest('.xterm')?.remove();
+  });
+
+  it('should reset scrollTop to 0 when scroll fires in alternate screen', () => {
+    let bufferType = 'alternate';
+    cleanup = installScrollLock(viewport, () => bufferType);
+
+    // Simulate xterm auto-scroll: set scrollTop to non-zero
+    Object.defineProperty(viewport, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+    (viewport as any).scrollTop = 150;
+    viewport.dispatchEvent(new Event('scroll'));
+
+    expect(viewport.scrollTop).toBe(0);
+  });
+
+  it('should NOT reset scrollTop in normal screen (allow user scrollback)', () => {
+    let bufferType = 'normal';
+    cleanup = installScrollLock(viewport, () => bufferType);
+
+    Object.defineProperty(viewport, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+    (viewport as any).scrollTop = 200;
+    viewport.dispatchEvent(new Event('scroll'));
+
+    // Normal screen: scroll position should be preserved
+    expect(viewport.scrollTop).toBe(200);
+  });
+
+  it('should handle rapid screen transitions without stale scroll corrections', () => {
+    let bufferType = 'alternate';
+    cleanup = installScrollLock(viewport, () => bufferType);
+
+    Object.defineProperty(viewport, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+
+    // Alternate screen: should reset
+    (viewport as any).scrollTop = 100;
+    viewport.dispatchEvent(new Event('scroll'));
+    expect(viewport.scrollTop).toBe(0);
+
+    // Switch to normal screen: should preserve
+    bufferType = 'normal';
+    (viewport as any).scrollTop = 300;
+    viewport.dispatchEvent(new Event('scroll'));
+    expect(viewport.scrollTop).toBe(300);
+
+    // Switch back to alternate: should reset again
+    bufferType = 'alternate';
+    viewport.dispatchEvent(new Event('scroll'));
+    expect(viewport.scrollTop).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

Rocket scrolling reappears in tile mode during heavy output from AI CLI tools (e.g., a multi-repo PR review task). The top-left tile's terminal content rapidly jumps/scrolls.

## Root Cause

xterm.js v6 processes `term.write()` asynchronously — between enqueue and write callback, the browser may paint one or more frames where xterm has auto-scrolled the viewport to the cursor position. The TerminalWriter's scrollTop correction in the write callback fires *after* this intermediate render, causing visible "rocket scroll" in tile mode.

Additionally:
- The `scaleTiles` function checks alternate screen *before* a 50ms setTimeout but calls `scrollToBottom()` *after* it — a race if the terminal transitions to alternate screen during the delay
- The write callback used a captured `inAlternateScreen` value from enqueue time, which could be stale if the buffer type changed during async processing

## Fix

Three-layer defense:

1. **Persistent viewport scroll lock** — A scroll event listener on `.xterm-viewport` enforces `scrollTop=0` during alternate screen mode, catching ALL scroll sources (writes, fitAddon.fit(), resize) before the browser paints
2. **Re-check buffer type in write callback** — Uses `this.term.buffer.active.type` at callback time instead of the captured value from flush start
3. **Double-check in scaleTiles setTimeout** — Re-checks alternate screen inside the 50ms timeout callback to prevent race with screen transitions

## Testing

- 3 new regression tests for viewport scroll lock behavior
- All 112 frontend + 109 server tests pass